### PR TITLE
Added netcoreapp3.1 target framework to support .NET Core 3.1

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,16 +9,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet: [ '5.0.x' ]
-    name: Build Dotnet ${{ matrix.dotnet }}
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET
+    - name: Setup dotnet 3.1
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: ${{ matrix.dotnet }}
+        dotnet-version: '3.1.x'
+    - name: Setup dotnet 5.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
             We can set the target of all projects here.
             This may be Overridden per project if needed, however pleas don't.
         -->
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
 
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,5 +15,7 @@
         <PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
         <PackageVersion Include="System.CommandLine.Rendering" Version="0.3.0-alpha.20574.7" />
         <PackageVersion Include="LibGit2Sharp" Version="0.27.0-preview-0096" />
+
+        <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     </ItemGroup>
 </Project>

--- a/src/dotnet-affected/dotnet-affected.csproj
+++ b/src/dotnet-affected/dotnet-affected.csproj
@@ -28,6 +28,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Win32.Registry" />
         <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
         <PackageReference Include="Microsoft.Build.Locator" />
         <PackageReference Include="System.CommandLine" />


### PR DESCRIPTION
This PR will add the netcoreapp3.1 target framework to support .NET Core 3.1 so you can install this tool in a repository that uses .NET Core 3.1 in its global.json file.

Fixes #2.