### PR TITLE
Added --solution-path option for getting projects from a solution file

### DIFF
--- a/src/dotnet-affected/Commands/AffectedRootCommand.cs
+++ b/src/dotnet-affected/Commands/AffectedRootCommand.cs
@@ -1,4 +1,4 @@
-﻿using Affected.Cli.Views;
+using Affected.Cli.Views;
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
@@ -18,6 +18,7 @@ namespace Affected.Cli.Commands
             this.AddCommand(new ChangesCommand());
 
             this.AddGlobalOption(new RepositoryPathOptions());
+            this.AddGlobalOption(new SolutionPathOption());
             this.AddGlobalOption(new VerboseOption());
             this.AddGlobalOption(new AssumeChangesOption());
 
@@ -60,6 +61,15 @@ namespace Affected.Cli.Commands
                 this.Description = "Path to the root of the repository, where the .git directory is." +
                     Environment.NewLine +
                     "[default: current directory]";
+            }
+        }
+
+        private class SolutionPathOption : Option<string>
+        {
+            public SolutionPathOption()
+                : base(new [] { "--solution-path" })
+            {
+                this.Description = "The path to the solution to resolve project files from. When omitted scans all directories in repository for project files instead.";
             }
         }
 

--- a/src/dotnet-affected/Commands/AffectedRootCommand.cs
+++ b/src/dotnet-affected/Commands/AffectedRootCommand.cs
@@ -69,7 +69,7 @@ namespace Affected.Cli.Commands
             public SolutionPathOption()
                 : base(new [] { "--solution-path" })
             {
-                this.Description = "The path to the solution to resolve project files from. When omitted scans all directories in repository for project files instead.";
+                this.Description = "Path to a Solution file (.sln) used to find all projects that may be affected. When omitted, will search for project files inside --repository-path.";
             }
         }
 

--- a/src/dotnet-affected/Commands/Context/CommandExecutionContext.cs
+++ b/src/dotnet-affected/Commands/Context/CommandExecutionContext.cs
@@ -68,8 +68,6 @@ namespace Affected.Cli.Commands
         private ProjectGraph BuildProjectGraph()
         {
             // Find all csproj and build the dependency tree
-            this.WriteLine($"Finding all csproj at {this.executionData.RepositoryPath}");
-
             var allProjects = !string.IsNullOrWhiteSpace(this.executionData.SolutionPath) 
                 ? FindProjectsInSolution() 
                 : FindProjectsInDirectory();
@@ -85,6 +83,8 @@ namespace Affected.Cli.Commands
 
         private IEnumerable<string> FindProjectsInSolution()
         {
+            this.WriteLine($"Finding all projects from Solution {this.executionData.SolutionPath}");
+
             var solution = SolutionFile.Parse(this.executionData.SolutionPath);
 
             return solution.ProjectsInOrder
@@ -94,6 +94,8 @@ namespace Affected.Cli.Commands
 
         private IEnumerable<string> FindProjectsInDirectory()
         {
+            this.WriteLine($"Finding all csproj at {this.executionData.RepositoryPath}");
+
             // TODO: Find *.*proj ?
             return Directory.GetFiles(
                 this.executionData.RepositoryPath,

--- a/src/dotnet-affected/Commands/Context/CommandExecutionData.cs
+++ b/src/dotnet-affected/Commands/Context/CommandExecutionData.cs
@@ -16,6 +16,7 @@ namespace Affected.Cli.Commands
 
         public CommandExecutionData(
            string? repositoryPath,
+           string? solutionPath,
            string? from,
            string to,
            bool verbose,
@@ -23,6 +24,7 @@ namespace Affected.Cli.Commands
            IConsole console)
         {
             this.RepositoryPath = repositoryPath ?? Environment.CurrentDirectory;
+            this.SolutionPath = solutionPath;
             this.To = to;
             this.From = from;
             this.Verbose = verbose;
@@ -31,12 +33,14 @@ namespace Affected.Cli.Commands
         }
 
         public string RepositoryPath { get; }
-
+        public string? SolutionPath { get; set; }
+        
         public string? From { get; }
 
         public string To { get; }
 
         public bool Verbose { get; }
+
 
         public IEnumerable<string> AssumeChanges { get; }
 


### PR DESCRIPTION
This will add the feature to read the projects from a solution, this can come in handy in case your repository contains more projects than the projects you would like to scan for changes that affect those.

Help file will look like this:

```
affected
  Determines which projects are affected by a set of changes.

Usage:
  affected [options] [command]

Options:
  -p, --repository-path <repository-path>  Path to the root of the repository, where the .git directory is.
                                           [default: current directory]
  --solution-path <solution-path>          The path to the solution to resolve project files from. When omitted scans
                                           all directories in repository for project files instead.
  -v, --verbose                            Write useful messages or just the desired output. [default: False]
  --assume-changes <assume-changes>        Hypothetically assume that given projects have changed instead of using Git
                                           diff to determine them.
  --from <from>                            A branch or commit to compare against --to.
  --to <to>                                A branch or commit to compare against --from
  --version                                Show version information
  -?, -h, --help                           Show help and usage information

Commands:
  generate  Generates a Microsoft.Sdk.Traversal project which includes all affected projects as build targets.
  changes   Finds projects that have any changes in any of its files using Git
```

Do you think an option shorthand like `-s` would be preferred?

Fixed #4 