### PR TITLE
ci: run tool in pipeline

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,6 +28,8 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build --no-restore --output $GITHUB_WORKSPACE/dotnet-output
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test $GITHUB_WORKSPACE/dotnet-output --no-build --verbosity normal
+    - name: Run Tool
+      run: $GITHUB_WORKSPACE/dotnet-output/dotnet-affected --assume-changes dotnet-affected --verbose

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -32,4 +32,4 @@ jobs:
     - name: Test
       run: dotnet test --no-build --verbosity normal
     - name: Run Tool
-      run: ./src/dotnet-affected/bin/Debug/net5.0/dotnet-affected -p $GITHUB_WORKSPACE --assume-changes dotnet-affected -v
+      run: ./src/dotnet-affected/bin/Debug/net5.0/dotnet-affected generate -p $GITHUB_WORKSPACE --assume-changes dotnet-affected -v

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,10 +25,8 @@ jobs:
       run: |
         ./eng/install-sdk.sh
         echo "DOTNET_ROOT=$GITHUB_WORKSPACE/eng/.dotnet" >> $GITHUB_ENV
-    - name: Restore dependencies
-      run: dotnet restore
     - name: Build
-      run: dotnet build --no-restore --output $RUNNER_TEMP/dotnet-output
+      run: dotnet build --output $RUNNER_TEMP/dotnet-output
     - name: Test
       run: dotnet test $RUNNER_TEMP/dotnet-output --no-build --verbosity normal
     - name: Run Tool

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,8 +28,8 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --no-restore --output $GITHUB_WORKSPACE/dotnet-output
+      run: dotnet build --no-restore --output $RUNNER_TEMP/dotnet-output
     - name: Test
-      run: dotnet test $GITHUB_WORKSPACE/dotnet-output --no-build --verbosity normal
+      run: dotnet test $RUNNER_TEMP/dotnet-output --no-build --verbosity normal
     - name: Run Tool
-      run: $GITHUB_WORKSPACE/dotnet-output/dotnet-affected --assume-changes dotnet-affected --verbose
+      run: $RUNNER_TEMP/dotnet-output/dotnet-affected --assume-changes dotnet-affected --verbose

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,9 +25,11 @@ jobs:
       run: |
         ./eng/install-sdk.sh
         echo "DOTNET_ROOT=$GITHUB_WORKSPACE/eng/.dotnet" >> $GITHUB_ENV
+    - name: Restore dependencies
+      run: dotnet restore
     - name: Build
-      run: dotnet build --output $RUNNER_TEMP/dotnet-output
+      run: dotnet build --no-restore
     - name: Test
-      run: dotnet test $RUNNER_TEMP/dotnet-output --no-build --verbosity normal
+      run: dotnet test --no-build --verbosity normal
     - name: Run Tool
-      run: $RUNNER_TEMP/dotnet-output/dotnet-affected --assume-changes dotnet-affected --verbose
+      run: ./src/dotnet-affected/bin/Debug/net5.0/dotnet-affected -p $GITHUB_WORKSPACE --assume-changes dotnet-affected -v

--- a/eng/install-sdk.sh
+++ b/eng/install-sdk.sh
@@ -14,4 +14,4 @@ global_json_file="$(dirname "$0")/../global.json"
 dotnet_install_dir="$(dirname "$0")/.dotnet"
 
 "$install_script" --install-dir "$dotnet_install_dir" --jsonfile "$global_json_file"
-"$install_script" --install-dir "$dotnet_install_dir" --channel 3.0
+"$install_script" --install-dir "$dotnet_install_dir" --channel 3.1

--- a/src/dotnet-affected/Views/ViewRenderingContext.cs
+++ b/src/dotnet-affected/Views/ViewRenderingContext.cs
@@ -24,9 +24,7 @@ namespace Affected.Cli.Views
 
         public void Render(View rootView)
         {
-            var screen = new ScreenView(renderer: this.ConsoleRenderer, this.Console);
-            screen.Child = rootView;
-            screen.Render(Region.EntireTerminal);
+            rootView.Render(this.ConsoleRenderer, Region.EntireTerminal);
         }
     }
 }


### PR DESCRIPTION
Runs the tool in CI just to prove the resulting binary works.

Fixes #6 
Underlying issue was that piping the output of the CLI was not working. i.e
```bash
# this was not failing before. CI tools must probably do this, hence it failed there as well
dotnet affected  [..] > output.txt
```


