### PR TITLE
Add cache to store repeated dependency tree calcs

### DIFF
--- a/src/dotnet-affected/ProjectGraphExtensions.cs
+++ b/src/dotnet-affected/ProjectGraphExtensions.cs
@@ -73,7 +73,7 @@ namespace Affected.Cli
         {
             return Cache.GetOrAdd(
                 targetNode.ProjectInstance.FullPath,
-                s => FindNodesThatDependOnImpl(graph, targetNode)); 
+                s => FindNodesThatDependOnImpl(graph, targetNode).ToList()); 
         }
 
         internal static IEnumerable<ProjectGraphNode> FindNodesContainingFiles(


### PR DESCRIPTION
When running this against a large solution, it was found to be very inefficient - recalculating the same dependency paths again and again.  Added this simple cache to resolve this.  I left this executing for 15mins+ before cancelling.  After this fix, the same command returned in < 5 seconds.