### PR TITLE
chore: micro & macrobenchmarks

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
         <PackageVersion Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
         <PackageVersion Include="System.CommandLine.Rendering" Version="0.4.0-alpha.22114.1" />
         <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta3.22114.1" />
+        <PackageVersion Include="System.CodeDom" Version="6.0.0" />
         <PackageVersion Include="LibGit2Sharp" Version="0.27.0-preview-0175" />
         <PackageVersion Include="MinVer" Version="2.5.0" />
 

--- a/src/dotnet-affected.Benchmarks/AffectedBenchmark.cs
+++ b/src/dotnet-affected.Benchmarks/AffectedBenchmark.cs
@@ -1,0 +1,100 @@
+﻿using Affected.Cli.Commands;
+using Affected.Cli.Tests;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Build.Graph;
+using Microsoft.Build.Locator;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using System;
+using System.CommandLine;
+using System.CommandLine.IO;
+using System.CommandLine.Rendering;
+using System.Linq;
+
+namespace Affected.Cli.Benchmarks
+{
+    /// <summary>
+    ///     Benchmarks the affected detection algorithm AFTER
+    ///     project discovery and building the MSBuild graph.
+    /// </summary>
+    [MemoryDiagnoser]
+    public class AffectedBenchmarks
+    {
+        static AffectedBenchmarks()
+        {
+            MSBuildLocator.RegisterDefaults();
+        }
+
+        [Params(500, 1000)] public int TotalProjects { get; set; }
+
+        [Params(20)] public int ChildrenPerProject { get; set; }
+
+        private TemporaryRepository Repository { get; } = new();
+
+        private ProjectGraph Graph { get; set; }
+
+        private ICommandExecutionContext Context { get; set; }
+
+        private ServiceProvider ServiceProvider { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            Console.WriteLine("Seeding project graph");
+            // Create a random tree of csproj
+            var rootNodes = Repository
+                .CreateTree(TotalProjects, ChildrenPerProject)
+                .ToList();
+
+            // Commit so there are no changes
+            Repository.StageAndCommit();
+
+            // Add random files to the tree so that some projects have changes
+            var graph = new ProjectGraph(rootNodes.Select(x => x.FullPath));
+            Repository.RandomizeChangesInProjectTree(graph);
+
+            Console.WriteLine($"Seeded graph with total of {graph.ProjectNodes.Count()} " +
+                              $"projects in {graph.ConstructionMetrics.ConstructionTime}");
+
+            ServiceProvider = AffectedCli
+                .CreateAffectedCommandLineBuilder()
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton<IConsole, SystemConsole>();
+                    services.AddSingleton<ITerminal, SystemConsoleTerminal>();
+                    services.Replace(ServiceDescriptor.Singleton(new CommandExecutionData(
+                        Repository.Path,
+                        string.Empty,
+                        String.Empty,
+                        String.Empty,
+                        true,
+                        Enumerable.Empty<string>(),
+                        Array.Empty<string>(),
+                        true,
+                        string.Empty,
+                        string.Empty)));
+                })
+                .ComposeServiceCollection()
+                .BuildServiceProvider();
+
+            Context = ServiceProvider.GetRequiredService<ICommandExecutionContext>();
+
+            // REMARKS: Ensure the graph is composed at setup time
+            Graph = ServiceProvider.GetRequiredService<IProjectGraphRef>()
+                .Value;
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanUp()
+        {
+            Repository.Dispose();
+        }
+
+        [Benchmark]
+        public int AffectedAlgorithm()
+        {
+            return Context.AffectedProjects.ToList()
+                .Count;
+        }
+    }
+}

--- a/src/dotnet-affected.Benchmarks/MacroBenchmarks.cs
+++ b/src/dotnet-affected.Benchmarks/MacroBenchmarks.cs
@@ -8,46 +8,52 @@ using System.Linq;
 
 namespace Affected.Cli.Benchmarks
 {
+    /// <summary>
+    ///     Benchmarks the equivalent of running `dotnet affected`
+    ///     Complete dotnet-affected benchmark with I/O.
+    /// </summary>
     [MemoryDiagnoser]
-    public class InvocationBenchmarks
+    public class MacroBenchmarks
     {
-        [Params(500, 1000)] public int TotalProjects { get; set; }
-
-        [Params(20)] public int ChildrenPerProject { get; set; }
-
-        static InvocationBenchmarks()
+        static MacroBenchmarks()
         {
             MSBuildLocator.RegisterDefaults();
         }
 
-        private TemporaryRepository Repository { get; } = new TemporaryRepository();
+        [Params(500, 1000)] public int TotalProjects { get; set; }
+
+        [Params(20)] public int ChildrenPerProject { get; set; }
+
+        private TemporaryRepository Repository { get; } = new();
 
         [GlobalSetup]
         public void GlobalSetup()
         {
+            Console.WriteLine("Seeding project graph");
             // Create a random tree of csproj
-            var rootNodes = this.Repository
+            var rootNodes = Repository
                 .CreateTree(TotalProjects, ChildrenPerProject)
                 .ToList();
 
             // Commit so there are no changes
-            this.Repository.StageAndCommit();
+            Repository.StageAndCommit();
 
             // Add random files to the tree so that some projects have changes
             var graph = new ProjectGraph(rootNodes.Select(x => x.FullPath));
-            this.Repository.RandomizeChangesInProjectTree(graph);
+            Repository.RandomizeChangesInProjectTree(graph);
 
-            Console.WriteLine($"Seeded graph with total of {graph.ProjectNodes.Count()} projects in {graph.ConstructionMetrics.ConstructionTime}");
+            Console.WriteLine($"Seeded graph with total of {graph.ProjectNodes.Count()} " +
+                              $"projects in {graph.ConstructionMetrics.ConstructionTime}");
         }
 
         [GlobalCleanup]
         public void GlobalCleanUp()
         {
-            this.Repository.Dispose();
+            Repository.Dispose();
         }
 
         [Benchmark]
-        public int Benchmark()
+        public int MacroBenchmark()
         {
             var exitCode = AffectedCli
                 .CreateAffectedCommandLineBuilder()

--- a/src/dotnet-affected.Benchmarks/dotnet-affected.Benchmarks.csproj
+++ b/src/dotnet-affected.Benchmarks/dotnet-affected.Benchmarks.csproj
@@ -12,15 +12,16 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
-        <PackageReference Include="Microsoft.Build.Locator" />
+        <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime"/>
+        <PackageReference Include="Microsoft.Build.Locator"/>
+        <PackageReference Include="System.CodeDom"/>
 
-        <PackageReference Include="BenchmarkDotNet" />
-        <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Condition="'$(OS)' == 'Windows_NT'" />
+        <PackageReference Include="BenchmarkDotNet"/>
+        <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Condition="'$(OS)' == 'Windows_NT'"/>
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="$(CliPath)dotnet-affected.csproj" />
-        <ProjectReference Include="../dotnet-affected.Tests/dotnet-affected.Tests.csproj" />
+        <ProjectReference Include="$(CliPath)dotnet-affected.csproj"/>
+        <ProjectReference Include="../dotnet-affected.Tests/dotnet-affected.Tests.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/dotnet-affected.Tests/Utils/Repository/TemporaryRepositoryExtensions.cs
+++ b/src/dotnet-affected.Tests/Utils/Repository/TemporaryRepositoryExtensions.cs
@@ -98,7 +98,16 @@ namespace Affected.Cli.Tests
             await File.WriteAllTextAsync(path, contents);
         }
 
-        public static IEnumerable<ProjectRootElement> CreateTree(
+        /// <summary>
+        /// Creates a tree of csproj with a total of <paramref name="totalProjects" />
+        /// Each project will try to have <paramref name="childrenPerProject" /> without
+        /// surpassing the <paramref name="totalProjects" /> count.
+        /// </summary>
+        /// <param name="repository"></param>
+        /// <param name="totalProjects"></param>
+        /// <param name="childrenPerProject"></param>
+        /// <returns></returns>
+        public static IEnumerable<ProjectRootElement> CreateCsProjTree(
             this TemporaryRepository repository,
             int totalProjects,
             int childrenPerProject)
@@ -132,18 +141,29 @@ namespace Affected.Cli.Tests
             } while (currentProjects < totalProjects);
         }
 
-        public static void RandomizeChangesInProjectTree(
+        /// <summary>
+        /// Adds a .cs file every <paramref name="everyProjectCount" />
+        /// Useful for making changes to a tree of csproj created with <see cref="CreateCsProjTree" />.
+        /// </summary>
+        /// <param name="repository"></param>
+        /// <param name="graph"></param>
+        /// <param name="everyProjectCount"></param>
+        public static async Task MakeChangesInProjectTree(
             this TemporaryRepository repository,
-            ProjectGraph graph)
+            ProjectGraph graph,
+            int everyProjectCount = 5)
         {
             var current = 0;
             foreach (var node in graph.ProjectNodes)
             {
-                if (current % 5 != 0) continue;
+                if (current % everyProjectCount != 0)
+                {
+                    continue;
+                }
 
                 var filePath = Path.Combine(node.ProjectInstance.Directory, $"file-{current}.cs");
                 var fileContents = $"// contents {current}";
-                Task.Run(() => repository.CreateTextFileAsync(filePath, fileContents));
+                await repository.CreateTextFileAsync(filePath, fileContents);
 
                 current++;
             }


### PR DESCRIPTION
The macrobenchmark does a complete I/O benchmark. It is the same as running `dotnet affected` command.
It discovers csproj files, creates an MSBuild project graph and then applies the detection algorithms.

The microbenchmark runs the detection algorithm only. The Projects are already discovered and the ProjectGraph is already built.

According to my profiling, the most time consumer method is the building of the `ProjectGraph`.
Instantiating `ProjectGraph` for 1k SDK based projects takes `~5s` and `3GB` ram :open_mouth: 


``` ini

BenchmarkDotNet=v0.13.1, OS=manjaro 
11th Gen Intel Core i7-1165G7 2.80GHz, 1 CPU, 8 logical and 4 physical cores
.NET SDK=6.0.200
  [Host]     : .NET 6.0.2 (6.0.222.6406), X64 RyuJIT
  Job-NDREBB : .NET 6.0.2 (6.0.222.6406), X64 RyuJIT

Toolchain=.NET 6.0  WarmupCount=1  

```
|            Method | TotalProjects | ChildrenPerProject |      Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Allocated |
|------------------ |-------------- |------------------- |----------:|----------:|----------:|-------:|-------:|----------:|
| **AffectedAlgorithm** |           **500** |                 **20** |  **57.42 μs** |  **0.366 μs** |  **0.324 μs** | **3.1128** | **0.1221** |     **19 KB** |
| **AffectedAlgorithm** |          **1000** |                 **20** | **925.54 μs** | **18.312 μs** | **19.593 μs** |      **-** |      **-** |     **67 KB** |

|         Method | TotalProjects | ChildrenPerProject |    Mean |    Error |   StdDev |       Gen 0 |       Gen 1 |     Gen 2 | Allocated |
|--------------- |-------------- |------------------- |--------:|---------:|---------:|------------:|------------:|----------:|----------:|
| **MacroBenchmark** |           **500** |                 **20** | **2.654 s** | **0.0531 s** | **0.1261 s** | **266000.0000** |  **53000.0000** | **1000.0000** |      **1 GB** |
| **MacroBenchmark** |          **1000** |                 **20** | **5.687 s** | **0.1134 s** | **0.2185 s** | **546000.0000** | **107000.0000** | **1000.0000** |      **3 GB** |


Gonna research if there are ways to improve this by configuring the `ProjectGraph`, but now we have a way to measure it.
We could add a separate benchmark for `ProjectGraph` instantiation only in order to measure this.

I did notice that if the project has no `Sdk` defined, it takes significantly less time/resources.
However, we will need to have the `Sdk` defined in order to use Predictions in PR #46 