### PR TITLE
feat: msbuild task

### DIFF
--- a/src/dotnet-affected/DotnetAffectedMSBuildTask.cs
+++ b/src/dotnet-affected/DotnetAffectedMSBuildTask.cs
@@ -1,0 +1,33 @@
+﻿using DotnetAffected.Core;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.Linq;
+
+namespace Affected
+{
+    /// <summary>
+    /// Simplest example of an msbuild task
+    /// </summary>
+    public class AffectedTask : Task
+    {
+        public override bool Execute()
+        {
+            Log.LogMessage("Starting Affected Task");
+            var options = new AffectedOptions(
+                this.RepositoryPath);
+            var graph = new ProjectGraphFactory(options)
+                .BuildProjectGraph();
+            var executor = new AffectedExecutor(options, graph);
+            var summary = executor.Execute();
+
+            this.AffectedProjects = string.Join(",",
+                summary.AffectedProjects.Select(p => p.GetFullPath()));
+
+            return true;
+        }
+
+        [Required] public string RepositoryPath { get; set; }
+
+        [Output] public string AffectedProjects { get; set; }
+    }
+}

--- a/src/dotnet-affected/dotnet-affected.csproj
+++ b/src/dotnet-affected/dotnet-affected.csproj
@@ -34,4 +34,15 @@
         <ProjectReference Include="$(SourcesPath)DotnetAffected.Core\DotnetAffected.Core.csproj"/>
     </ItemGroup>
 
+    <UsingTask TaskName="Affected.AffectedTask"
+               AssemblyFile="bin\Debug\net6.0\dotnet-affected.dll"/>
+
+    <Target Name="Affected" Outputs="ProjectReferenceWithConfiguration">
+        <AffectedTask RepositoryPath="../../">
+            <Output TaskParameter="AffectedProjects" PropertyName="AffectedProjects"/>
+        </AffectedTask>
+        <Message Importance="high" Text="These are affected: $(AffectedProjects)"/>
+        <!-- What do I do with $(AffectedProjects? how do I invoke the original `build`/`test`/etc command?-->
+    </Target>
+
 </Project>


### PR DESCRIPTION
This is the first time I'm doing this so bare with me..

Adds a simple MSBuild Task that executes dotnet affected and outputs a comma separated list of the affected projects path.

After making a dumb change:
```
dotnet build ./src/dotnet-affected /t:affected
  [..]
  These are affected: /home/lchaia/dev/dotnet-affected/benchmarks/dotnet-affected.Benchmarks/dotnet-affected.Benchmarks.csproj,/home/lchaia/dev/dotnet-affected/test/dotnet-affected.Tests/dotnet-affected.Tests.csproj
```

I think the next step would be to "execute the original build/test/whatever task" but using the affected project list