### PR TITLE
feature: support Proper project evaluation of import statements

### DIFF
--- a/src/DotnetAffected.Abstractions/IChangesProvider.cs
+++ b/src/DotnetAffected.Abstractions/IChangesProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.Build.Evaluation;
+using System.Collections.Generic;
 
 namespace DotnetAffected.Abstractions
 {
@@ -17,18 +18,16 @@ namespace DotnetAffected.Abstractions
         IEnumerable<string> GetChangedFiles(string directory, string from, string to);
 
         /// <summary>
-        /// Uses the underlying changes provider to get
-        /// the text contents of a file at <paramref name="from"/> and at <paramref name="to"/>.
+        /// Uses the underlying changes provider to load a <see cref="Project"/> file at <paramref name="commitRef"/>.
         /// </summary>
         /// <param name="directory"></param>
         /// <param name="pathToFile"></param>
-        /// <param name="from"></param>
-        /// <param name="to"></param>
+        /// <param name="commitRef"></param>
+        /// <param name="fallbackToHead">When true, uses the HEAD as the default commit, otherwise uses the current working directory. <br/>
+        /// Applicable only when <paramref name="commitRef"/> is null or empty.</param>
         /// <returns></returns>
-        (string? FromText, string? ToText) GetTextFileContents(
-            string directory,
-            string pathToFile,
-            string from,
-            string to);
+        Project? LoadProject(string directory, string pathToFile, string? commitRef, bool fallbackToHead);
+
+        Project? LoadDirectoryPackagePropsProject(string directory, string pathToFile, string? commitRef, bool fallbackToHead);
     }
 }

--- a/src/DotnetAffected.Core/AssumptionChangesProvider.cs
+++ b/src/DotnetAffected.Core/AssumptionChangesProvider.cs
@@ -1,4 +1,6 @@
 ﻿using DotnetAffected.Abstractions;
+using LibGit2Sharp;
+using Microsoft.Build.Evaluation;
 using Microsoft.Build.Graph;
 using System.Collections.Generic;
 using System.Linq;
@@ -34,10 +36,14 @@ namespace DotnetAffected.Core
                 .FindNodesByName(_assumptions)
                 .Select(n => n.ProjectInstance.FullPath);
         }
-
+        
         /// <inheritdoc />
-        public (string FromText, string ToText) GetTextFileContents(string directory, string pathToFile, string from,
-            string to)
+        public Project? LoadProject(string directory, string pathToFile, string? commitRef, bool fallbackToHead)
+        {
+            throw new System.InvalidOperationException("--assume-changes should not try to access file contents");
+        }
+
+        public Project? LoadDirectoryPackagePropsProject(string directory, string pathToFile, string? commitRef, bool fallbackToHead)
         {
             throw new System.InvalidOperationException("--assume-changes should not try to access file contents");
         }

--- a/src/DotnetAffected.Core/DotnetAffected.Core.csproj
+++ b/src/DotnetAffected.Core/DotnetAffected.Core.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="$(PackageDefaultsPropsPath)"/>
+    <Import Project="$(PackageDefaultsPropsPath)" />
 
     <PropertyGroup>
         <RootNamespace>DotnetAffected.Core</RootNamespace>
     </PropertyGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SourcesPath)/DotnetAffected.Abstractions/DotnetAffected.Abstractions.csproj"/>
+        <ProjectReference Include="$(SourcesPath)/DotnetAffected.Abstractions/DotnetAffected.Abstractions.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build.Prediction"/>
-        <PackageReference Include="LibGit2Sharp"/>
+        <PackageReference Include="Microsoft.Build.Prediction" />
+        <PackageReference Include="LibGit2Sharp" />
     </ItemGroup>
 </Project>

--- a/src/DotnetAffected.Core/FileSystem/EagerCachingMsBuildGitFileSystem.cs
+++ b/src/DotnetAffected.Core/FileSystem/EagerCachingMsBuildGitFileSystem.cs
@@ -1,0 +1,58 @@
+﻿using LibGit2Sharp;
+using Microsoft.Build.Evaluation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DotnetAffected.Core.FileSystem
+{
+    /// <summary>
+    /// A wrapper around the git filesystem that works around the MSBuild issue https://github.com/dotnet/msbuild/issues/7956 <br/>
+    /// The build process does not use the file system to ge the content of a file when it needs to load a nested project. <br/>
+    /// It will only use the file system to query if a file exists or not, if it exist it will just load the file using the file system <para/>
+    ///
+    /// To workaround it we simply listen to all FileExists requests and if the file exists and it's part of the <see cref="MsBuildGitFileSystem.UseFileSystem">commit</see>
+    /// we will eager load it on the spot, before the build will try to load it, so by the time the build loads it, it's in the cache. <br/>
+    ///
+    /// We only listen before we process the root file and stop right after the root is loaded.
+    /// </summary>
+    internal class EagerCachingMsBuildGitFileSystem : MsBuildGitFileSystem, IDisposable
+    {
+        private readonly Commit? _commit;
+        private ProjectFactory? _projectFactory;
+        private Action<string>? _onEagerCacheRequired;
+
+        public EagerCachingMsBuildGitFileSystem(Repository repository, Commit? commit) : base(repository, commit)
+        {
+            _commit = commit;
+        }
+        
+        /// <summary>
+        /// Use this for File.Exists(path)
+        /// </summary>
+        public override bool FileExists(string path)
+        {
+            var result = base.FileExists(path);
+            if (result && !UseFileSystem(path))
+                _onEagerCacheRequired?.Invoke(path);
+            return result;
+        }
+
+        public Project CreateProjectAndEagerLoadChildren(string path)
+        {
+            var projects = new List<Project>();
+            _projectFactory ??= new ProjectFactory(this, new ProjectCollection());
+
+            _onEagerCacheRequired = s => projects.Add(_projectFactory.CreateProject(s));
+            projects.Add(_projectFactory.CreateProject(path));
+            _onEagerCacheRequired = null;
+
+            return projects.Last();
+        }
+
+        public void Dispose()
+        {
+            _projectFactory?.Dispose();
+        }
+    }
+}

--- a/src/DotnetAffected.Core/FileSystem/MsBuildGitFileSystem.cs
+++ b/src/DotnetAffected.Core/FileSystem/MsBuildGitFileSystem.cs
@@ -1,0 +1,330 @@
+﻿using LibGit2Sharp;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.FileSystem;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Enumeration;
+using System.Text;
+
+namespace DotnetAffected.Core.FileSystem
+{
+    /// <summary>
+    /// An git <see cref="MSBuildFileSystemBase">MSBuild file system</see> implementation for project evaluation. <para/>
+    /// It is a <b>readonly</b> filesystem which exposes the filesystem in the state of the commit provided to it. <para/>
+    ///
+    /// <see cref="MsBuildGitFileSystem"/> is required for project imports references, e.g:
+    ///
+    /// <code>&lt;Import Project="path" /&gt;</code>
+    /// 
+    /// Where the <see cref="Project"/> build instance will dynamically load the referenced project at <b>path</b> which requires a file system
+    /// to load it from, in a git commit we need a virtual file system.
+    /// </summary>
+    /// <remarks>When commit is null the file system represents the current working directory.</remarks>
+    internal class MsBuildGitFileSystem : MSBuildFileSystemBase
+    {
+        private readonly Repository _repository;
+        private readonly Commit? _commit;
+
+        public MsBuildGitFileSystem(Repository repository, Commit? commit)
+        {
+            _repository = repository;
+            _commit = commit;
+        }
+
+        private string NormalizePathToWorkDir(string path) 
+            => Path.Combine(_repository.Info.WorkingDirectory, path);
+
+        private string NormalizePathToGitDir(string path)
+            => GitChangesProvider.IsWindows
+                ? Path.GetRelativePath(_repository.Info.WorkingDirectory, path).Replace('\\', '/')
+                : Path.GetRelativePath(_repository.Info.WorkingDirectory, path);
+
+        /// <summary>
+        /// Returns <b>true</b> when the path belongs to the file system and not to a commit. <br/>
+        /// Returns <b>false</b> when the path belongs to the commit. <para/>
+        ///
+        /// When a <paramref name="path"/> belongs to the file system it means that we will get file content for this
+        /// path from the file system. If not, it belongs to the commit so we will get the content from the commit. <para/>
+        /// 
+        /// There are 2 scenarios where a <paramref name="path"/> qualify as belonging to the file system:
+        ///
+        /// <list type="number">
+        ///   <item>There is no Commit (commit is null), i.e. this file system is pointing at the working directory. <br/> OR</item>
+        ///   <item>There is a Commit but the <paramref name="path"/> is outside of the boundaries of the repository.</item>
+        /// </list>
+        ///
+        /// The 2nd scenario states we're in file system representing the commit however, the <paramref name="path"/> might
+        /// reference a location on the disk not part of the repository so in that case we get the files from the file system.
+        ///
+        /// For example, If our project is located in `a/b/c/d/proj.csproj` <br/>
+        /// Any <paramref name="path"/> referencing `a/b/c/d/**.*` does not belong to the file system. <br/>
+        /// However, if it point to `a/b/w/p.props` it is not part of the repository so we will load it from the file system. <br/>
+        ///
+        /// MSBuild search for `Directory.Build.props` up to the root of the drive and also in SDK folders, outside of the
+        /// repository. Regardless of the commit, those files must serve from the disk.
+        /// </summary>
+        /// <param name="path"></param>
+        protected bool UseFileSystem(string path)
+            => _commit is null || !path.StartsWith(_repository.Info.WorkingDirectory);
+
+        private Stream GetFileStreamGit(Commit commit, string path)
+        {
+            var treeEntry = commit[NormalizePathToGitDir(path)];
+            var blob = (Blob)treeEntry.Target;
+            return blob.GetContentStream();
+        }
+
+        /// <summary>
+        /// Use this for var sr = new StreamReader(path)
+        /// </summary>
+        public override TextReader ReadFile(string path)
+        {
+            if (UseFileSystem(path))
+                return new StreamReader(NormalizePathToWorkDir(path));
+            return new StreamReader(GetFileStreamGit(_commit, path), Encoding.UTF8);
+        }
+
+        /// <summary>
+        /// Use this for new FileStream(path, mode, access, share)
+        /// </summary>
+        public override Stream GetFileStream(string path, FileMode mode, FileAccess access, FileShare share)
+        {
+            if (UseFileSystem(path))
+                return File.Open(NormalizePathToWorkDir(path), mode, access, share);
+
+            switch (mode)
+            {
+                case FileMode.CreateNew:
+                case FileMode.Create:
+                case FileMode.Truncate:
+                case FileMode.Append:
+                case FileMode.OpenOrCreate:
+                    throw new InvalidOperationException($"Git virtual filesystem is readonly. [FileMode: {mode.ToString()}]");
+                case FileMode.Open:
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mode), mode, null);
+            }
+
+            switch (access)
+            {
+                case FileAccess.Write:
+                case FileAccess.ReadWrite:
+                    throw new InvalidOperationException($"Git virtual filesystem is readonly. [FileAccess: {access.ToString()}]");
+                case FileAccess.Read:
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(access), access, null);
+            }
+
+            return GetFileStreamGit(_commit, path);
+        }
+
+        /// <summary>
+        /// Use this for File.ReadAllText(path)
+        /// </summary>
+        public override string ReadFileAllText(string path)
+        {
+            if (UseFileSystem(path))
+                return File.ReadAllText(NormalizePathToWorkDir(path));
+
+            using var tr = ReadFile(path);
+            return tr.ReadToEnd();
+        }
+
+        /// <summary>
+        /// Use this for File.ReadAllBytes(path)
+        /// </summary>
+        public override byte[] ReadFileAllBytes(string path) => Encoding.UTF8.GetBytes(ReadFileAllText(path));
+
+        /// <summary>
+        /// Use this for Directory.EnumerateFiles(path, pattern, option)
+        /// </summary>
+        public override IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        {
+            if (UseFileSystem(path))
+            {
+                foreach (var entry in Directory.EnumerateDirectories(NormalizePathToWorkDir(path), searchPattern, searchOption))
+                    yield return entry;
+            }
+            else
+            {
+                var d = (Tree)_commit[NormalizePathToGitDir(path)].Target;
+                foreach (var entry in d)
+                {
+                    if (entry.TargetType != TreeEntryTargetType.Blob)
+                        continue;
+                    if (FileSystemName.MatchesWin32Expression(searchPattern.AsSpan(), entry.Name, false))
+                    {
+                        yield return $"{path}{Path.DirectorySeparatorChar}{entry.Name}";
+                        if (searchOption == SearchOption.AllDirectories)
+                        {
+                            foreach (var sub in EnumerateFileSystemEntries($"{path}{Path.DirectorySeparatorChar}{entry.Name}", searchPattern, searchOption))
+                                yield return sub;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Use this for Directory.EnumerateFolders(path, pattern, option)
+        /// </summary>
+        public override IEnumerable<string> EnumerateDirectories(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        {
+            if (UseFileSystem(path))
+            {
+                foreach (var entry in Directory.EnumerateDirectories(NormalizePathToWorkDir(path), searchPattern, searchOption))
+                    yield return entry;
+            }
+            else
+            {
+                var d = (Tree)_commit[NormalizePathToGitDir(path)].Target;
+                foreach (var entry in d)
+                {
+                    if (entry.TargetType != TreeEntryTargetType.Tree)
+                        continue;
+                    if (FileSystemName.MatchesWin32Expression(searchPattern.AsSpan(), entry.Name, false))
+                    {
+                        yield return $"{path}{Path.DirectorySeparatorChar}{entry.Name}";
+                        if (searchOption == SearchOption.AllDirectories)
+                        {
+                            foreach (var sub in EnumerateFileSystemEntries($"{path}{Path.DirectorySeparatorChar}{entry.Name}", searchPattern, searchOption))
+                                yield return sub;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Use this for Directory.EnumerateFileSystemEntries(path, pattern, option)
+        /// </summary>
+        public override IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        {
+            if (UseFileSystem(path))
+            {
+                foreach (var entry in Directory.EnumerateFileSystemEntries(NormalizePathToWorkDir(path), searchPattern, searchOption))
+                    yield return entry;
+            }
+            else
+            {
+                var d = (Tree)_commit[NormalizePathToGitDir(path)].Target;
+                foreach (var entry in d)
+                {
+                    if (FileSystemName.MatchesWin32Expression(searchPattern.AsSpan(), entry.Name, false))
+                    {
+                        yield return $"{path}{Path.DirectorySeparatorChar}{entry.Name}";
+                        if (searchOption == SearchOption.AllDirectories)
+                        {
+                            foreach (var sub in EnumerateFileSystemEntries($"{path}{Path.DirectorySeparatorChar}{entry.Name}", searchPattern, searchOption))
+                                yield return sub;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Use this for File.GetAttributes()
+        /// </summary>
+        public override FileAttributes GetAttributes(string path) => DirectoryExists(path)
+            ? FileAttributes.Directory
+            : FileAttributes.Normal;
+
+        /// <summary>
+        /// Use this for File.GetLastWriteTimeUtc(path)
+        /// </summary>
+        public override DateTime GetLastWriteTimeUtc(string path)
+        {
+            if (UseFileSystem(path))
+                return new FileInfo(NormalizePathToWorkDir(path)).LastWriteTimeUtc;
+
+            return _commit.Author.When.UtcDateTime;
+        }
+
+        /// <summary>
+        /// Use this for Directory.Exists(path)
+        /// </summary>
+        public override bool DirectoryExists(string path)
+        {
+            if (UseFileSystem(path))
+                return File.Exists(NormalizePathToWorkDir(path));
+
+            var treeEntry = _commit[NormalizePathToGitDir(path)];
+            if (treeEntry == null)
+                return false;
+            switch (treeEntry.Mode)
+            {
+                case Mode.Directory:
+                    return true;
+                case Mode.Nonexistent:
+                case Mode.NonExecutableFile:
+                case Mode.NonExecutableGroupWritableFile:
+                case Mode.ExecutableFile:
+                case Mode.SymbolicLink:
+                case Mode.GitLink:
+                    return false;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        /// <summary>
+        /// Use this for File.Exists(path)
+        /// </summary>
+        public override bool FileExists(string path)
+        {
+            if (UseFileSystem(path))
+                return File.Exists(NormalizePathToWorkDir(path));
+
+            var treeEntry = _commit[NormalizePathToGitDir(path)];
+            if (treeEntry == null)
+                return false;
+            switch (treeEntry.Mode)
+            {
+                case Mode.Nonexistent:
+                case Mode.Directory:
+                    return false;
+                case Mode.NonExecutableFile:
+                case Mode.NonExecutableGroupWritableFile:
+                case Mode.ExecutableFile:
+                case Mode.SymbolicLink:
+                case Mode.GitLink:
+                    return true;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        /// <summary>
+        /// Use this for File.Exists(path) || Directory.Exists(path)
+        /// </summary>
+        public override bool FileOrDirectoryExists(string path)
+        {
+            if (UseFileSystem(path))
+            {
+                var p = NormalizePathToWorkDir(path);
+                return File.Exists(p) || Directory.Exists(p);
+            }
+            var treeEntry = _commit[NormalizePathToGitDir(path)];
+            if (treeEntry == null)
+                return false;
+            switch (treeEntry.Mode)
+            {
+                case Mode.Nonexistent:
+                    return false;
+                case Mode.Directory:
+                case Mode.NonExecutableFile:
+                case Mode.NonExecutableGroupWritableFile:
+                case Mode.ExecutableFile:
+                case Mode.SymbolicLink:
+                case Mode.GitLink:
+                    return true;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+    }
+}

--- a/src/DotnetAffected.Core/GitChangesProvider.cs
+++ b/src/DotnetAffected.Core/GitChangesProvider.cs
@@ -1,9 +1,16 @@
 ﻿using DotnetAffected.Abstractions;
+using DotnetAffected.Core.FileSystem;
 using LibGit2Sharp;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Definition;
+using Microsoft.Build.Evaluation;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
+using System.Xml;
 
 namespace DotnetAffected.Core
 {
@@ -12,6 +19,24 @@ namespace DotnetAffected.Core
     /// </summary>
     public class GitChangesProvider : IChangesProvider
     {
+        internal static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        private static readonly Lazy<bool> ResolveMsBuildFileSystemSupported = new Lazy<bool>(() =>
+        {
+            var versionInfo = FileVersionInfo.GetVersionInfo(typeof(Project).Assembly.Location);
+            if (versionInfo.FileMajorPart > 16)
+                return true;
+            if (versionInfo.FileMajorPart < 16)
+                return false;
+            return versionInfo.FileMinorPart >= 10;
+        });
+
+        /// <summary>
+        /// When true, the build system supports virtual filesystem which means nested Directory.Packages.props files
+        /// are supported in central package management.
+        /// </summary>
+        public static bool MsBuildFileSystemSupported => ResolveMsBuildFileSystemSupported.Value;
+
         /// <inheritdoc />
         public IEnumerable<string> GetChangedFiles(string directory, string from, string to)
         {
@@ -22,46 +47,109 @@ namespace DotnetAffected.Core
             return TreeChangesToPaths(changes, directory);
         }
 
+        public Project? LoadDirectoryPackagePropsProject(string directory, string pathToFile, string? commitRef, bool fallbackToHead)
+        {
+            var project = LoadProject(directory, pathToFile, commitRef, fallbackToHead);
+            if (project is null && MsBuildFileSystemSupported)
+            {
+                var fi = new FileInfo(pathToFile);
+                var parent = fi.Directory?.Parent?.FullName;
+                if (parent is not null && parent.Length >= directory.Length)
+                    return LoadDirectoryPackagePropsProject(directory, Path.Combine(parent, "Directory.Packages.props"), commitRef, fallbackToHead);
+            }
+
+            return project;
+        }
+
         /// <inheritdoc />
-        public (string? FromText, string? ToText) GetTextFileContents(
-            string directory,
-            string pathToFile,
-            string from,
-            string to)
+        public Project? LoadProject(string directory, string pathToFile, string? commitRef, bool fallbackToHead)
         {
+            return MsBuildFileSystemSupported
+                ? LoadProjectCore(directory, pathToFile, commitRef, fallbackToHead)
+                : LoadProjectLegacy(directory, pathToFile, commitRef, fallbackToHead);
+        }
+
+        private Project? LoadProjectCore(string directory, string pathToFile, string? commitRef, bool fallbackToHead)
+        {
+            Commit? commit;
+            
             using var repository = new Repository(directory);
+            
+            if (string.IsNullOrWhiteSpace(commitRef))
+                commit = fallbackToHead ? repository.Head.Tip : null;
+            else
+                commit = GetCommitOrThrow(repository, commitRef);
 
-            var (fromCommit, toCommit) = ParseRevisionRanges(repository, from, to);
-
-            pathToFile = Path.GetRelativePath(directory, pathToFile);
-
-            // Read file from commit or working directory
-            var fromText = fromCommit is null
-                ? ReadTextFileFromWorkingDirectory(directory, pathToFile)
-                : ReadTextFileFromCommit(pathToFile, fromCommit);
-
-            var toText = ReadTextFileFromCommit(pathToFile, toCommit);
-
-            return (fromText, toText);
+            /* TODO: Uncomment if/when https://github.com/dotnet/msbuild/issues/7956 is fixed. */
+            // using var projectFactory = new ProjectFactory(new MsBuildGitFileSystem(repository, commit), new ProjectCollection());
+            // return projectFactory.FileSystem.FileExists(pathToFile)
+            //     ? projectFactory.CreateProject(pathToFile)
+            //     : null;
+            
+            /* Workaround for https://github.com/dotnet/msbuild/issues/7956
+               For more information, see comments in EagerCachingMsBuildGitFileSystem
+               TODO: Delete EagerCachingMsBuildGitFileSystem and this code if/when 7956 is fixed. */
+            using var fs = new EagerCachingMsBuildGitFileSystem(repository, commit);
+            return fs.FileExists(pathToFile) ? fs.CreateProjectAndEagerLoadChildren(pathToFile) : null;
         }
 
-        private static string? ReadTextFileFromWorkingDirectory(string directory, string pathToFile)
+        private Project? LoadProjectLegacy(string directory, string pathToFile, string? commitRef, bool fallbackToHead)
         {
-            var path = Path.Combine(directory, pathToFile);
-            if (!File.Exists(path)) return null;
+            Commit? commit;
+            
+            using var repository = new Repository(directory);
+            
+            if (string.IsNullOrWhiteSpace(commitRef))
+                commit = fallbackToHead ? repository.Head.Tip : null;
+            else
+                commit = GetCommitOrThrow(repository, commitRef);
 
-            return File.ReadAllText(path);
-        }
+            Stream GenerateStreamFromString(string s)
+            {
+                var stream = new MemoryStream();
+                var writer = new StreamWriter(stream);
+                writer.Write(s);
+                writer.Flush();
+                stream.Position = 0;
+                return stream;
+            }
 
-        private static string? ReadTextFileFromCommit(string pathToFile, Commit commit)
-        {
-            var treeEntry = commit[pathToFile];
-            if (treeEntry == null) return null;
+            var projectCollection = new ProjectCollection();
 
-            var blob = (Blob)treeEntry.Target;
+            if (commit is null)
+            {
+                var path = Path.Combine(directory, pathToFile);
+                if (!File.Exists(path)) return null;
 
-            using var content = new StreamReader(blob.GetContentStream(), Encoding.UTF8);
-            return content.ReadToEnd();
+                using var reader = new XmlTextReader(GenerateStreamFromString(File.ReadAllText(path)));
+                var projectRootElement = ProjectRootElement.Create(reader);
+                projectRootElement.FullPath = pathToFile;
+                return Project.FromProjectRootElement(projectRootElement, new ProjectOptions
+                {
+                    LoadSettings = ProjectLoadSettings.Default,
+                    ProjectCollection = projectCollection,
+                });
+            }
+            else
+            {
+                var path = IsWindows
+                    ? Path.GetRelativePath(directory, pathToFile).Replace('\\', '/')
+                    : Path.GetRelativePath(directory, pathToFile);
+                var treeEntry = commit[path];
+                if (treeEntry == null) return null;
+
+                var blob = (Blob)treeEntry.Target;
+
+                using var content = new StreamReader(blob.GetContentStream(), Encoding.UTF8);
+                using var reader = new XmlTextReader(GenerateStreamFromString(content.ReadToEnd()));
+                var projectRootElement = ProjectRootElement.Create(reader);
+                projectRootElement.FullPath = pathToFile;
+                return Project.FromProjectRootElement(projectRootElement, new ProjectOptions
+                {
+                    LoadSettings = ProjectLoadSettings.Default,
+                    ProjectCollection = projectCollection,
+                });
+            }
         }
 
         private static (Commit? From, Commit To) ParseRevisionRanges(

--- a/src/DotnetAffected.Core/ProjectFactory.cs
+++ b/src/DotnetAffected.Core/ProjectFactory.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.Build.Construction;
+using Microsoft.Build.Definition;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Evaluation.Context;
+using Microsoft.Build.FileSystem;
+using System;
+using System.IO;
+using System.Xml;
+
+namespace DotnetAffected.Core
+{
+    internal class ProjectFactory : IDisposable
+    {
+        public readonly MSBuildFileSystemBase FileSystem;
+        public ProjectCollection ProjectCollection { get; }
+
+        public ProjectFactory(MSBuildFileSystemBase fileSystem, ProjectCollection? projectCollection = null)
+        {
+            FileSystem = fileSystem;
+            ProjectCollection = projectCollection ?? ProjectCollection.GlobalProjectCollection;
+            
+        }
+
+        private ProjectRootElement CreateProjectRootElement(string path)
+        {
+            // Loading using a file path will not work since creating/opening the root project is done directly, no virtual FS there.
+            // We must use a reader so we control where the content comes.
+            // Later, when we attach it to a Project, imports will be loaded via the git file system...
+            using var reader = new XmlTextReader(FileSystem.GetFileStream(path, FileMode.Open, FileAccess.Read, FileShare.None));
+            var projectRootElement = ProjectRootElement.Create(reader, ProjectCollection);
+
+            // Creating from an XML reader does not have a file system context, i.e. it does not know the root path.
+            // It will use the process root path.
+            // We need to set the exact path so dynamic imports are resolved relative to the original path.
+            // Not that this one must be the absolute path, not relative!
+            projectRootElement.FullPath = path;
+            return projectRootElement;
+        }
+
+        public Project CreateProject(string projectRootElementFilePath)
+        {
+            var projectRootElement = CreateProjectRootElement(projectRootElementFilePath);
+            return Project
+                .FromProjectRootElement(projectRootElement, new ProjectOptions
+                {
+                    LoadSettings = ProjectLoadSettings.Default,
+                    ProjectCollection = ProjectCollection,
+                    EvaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared, FileSystem),
+                });
+        }
+
+        public void Dispose()
+        {
+            ProjectCollection.Dispose();
+        }
+    }
+}

--- a/test/DotnetAffected.Core.Tests/CentralPackageManagementDetectionNestedTests.cs
+++ b/test/DotnetAffected.Core.Tests/CentralPackageManagementDetectionNestedTests.cs
@@ -1,0 +1,310 @@
+﻿using DotnetAffected.Testing.Utils;
+using System.Linq;
+using Xunit;
+
+namespace DotnetAffected.Core.Tests
+{
+    
+    /// <summary>
+    /// Tests for detecting affected projects when central package management changes with nested package files
+    /// </summary>
+    public class CentralPackageManagementDetectionNestedTests : BaseDotnetAffectedTest
+    {
+
+        /// <summary>
+        /// This test demonstrate the main difference when nest project evaluation is supported in DPP. <br/>
+        ///
+        /// <example>
+        /// <list type="bullet">
+        ///   <listheader><b>Initial FileSystem state (committed to git):</b></listheader>
+        ///   <item>Directory.Packages.props<br/>
+        ///     - Other.Library @ 2.5.0
+        ///   </item>
+        ///   <item>InventoryManagement/Directory.Packages.props<br/>
+        ///     - Some.Library  @ 3.0.0
+        ///   </item>
+        ///   <item>InventoryManagement/InventoryManagement.csproj</item>
+        /// </list>
+        /// 
+        /// <list type="bullet">
+        ///   <listheader><b>Updating files (working directory):</b></listheader>
+        ///   <item>Directory.Packages.props<br/>
+        ///     - Some.Library  @ 2.0.0
+        ///   </item>
+        ///   <item>InventoryManagement/Directory.Packages.props<br/>
+        ///     - Other.Library @ 3.5.0
+        ///   </item>
+        /// </list>
+        ///  
+        ///  In words, we've swapped the packages between the <b>Directory.Packages.props</b> files and changed the versions. <para/>
+        ///
+        /// <list type="bullet">
+        ///   <listheader><b>Real analysis (i.e. with project evaluation):</b></listheader>
+        ///   <item>Some.Library   PREV: 3.0.0 <b>CURR</b>: 2.0.0</item>
+        ///   <item>Other.Library  PREV: 2.5.0 <b>CURR</b>: 3.5.0</item>
+        /// </list>
+        /// 
+        /// <list type="bullet">
+        ///   <listheader><b>Old analysis (i.e. NO project evaluation):</b></listheader>
+        ///   <item>Some.Library   PREV: 3.0.0 <b>CURR</b>: 2.0.0</item>
+        ///   <item>Other.Library  PREV: NONE <b>CURR</b>: 3.5.0</item>
+        /// </list>
+        /// This is what we get when project evaluation is supported.<para/>
+        ///
+        /// Putting the history mismatches aside, the actual current package resolution fails! <br/>
+        /// It appears to bring the right values, but no! <br/>
+        /// It will first load the file `InventoryManagement/Directory.Packages.props` from the commit, with the right
+        /// value for `Other.Library` @ 3.50 however, for `Some.Library` it will just load the file from the file system,
+        /// not the commit. By luck it's the right value but if we we're to find the changeset between 2 commits and not between the working dir and HEAD, it would
+        /// have given us the wrong value!
+        /// </example>
+        /// </summary>
+        [Fact]
+        public void When_directory_packages_props_updates_dependant_projects_should_be_affected()
+        {
+            // TODO: Extend this test to find the changeset between 2 commits and not WorkDir <-> HEAD
+
+            // Create a Directory.Package.props
+            var packageName = "Some.Library";
+            var otherPackageName = "Other.Library";
+            Repository
+                .CreateDirectoryPackageProps(b => b.AddPackageVersion(otherPackageName, "2.5.0"));
+
+            // Create a project with a nuget dependency
+            var projectName = "InventoryManagement";
+            var msBuildProject = Repository.CreateCsProject(
+                projectName,
+                b => b.AddNuGetDependency(packageName));
+
+            msBuildProject
+                .CreateDirectoryPackageProps(true, b => b.AddPackageVersion(packageName, "3.0.0"));
+
+            // Commit so there are no changes
+            Repository.StageAndCommit();
+
+            msBuildProject.RemoveDirectoryPackageProps();
+            msBuildProject
+                .CreateDirectoryPackageProps(true, b => b.AddPackageVersion(otherPackageName, "3.5.0"));
+            
+            Repository.RemoveDirectoryPackageProps();
+            Repository.CreateDirectoryPackageProps(b => b.AddPackageVersion(packageName, "2.0.0"));
+
+            Assert.Equal(2, AffectedSummary.ChangedPackages.Length);
+            Assert.Single(AffectedSummary.AffectedProjects);
+            
+            var someLibChanges = AffectedSummary.ChangedPackages.Single(c => c.Name == packageName);
+            var otherLibChanges = AffectedSummary.ChangedPackages.Single(c => c.Name == otherPackageName);
+            
+#if (NET5_0_OR_GREATER)
+            Assert.Equal("3.0.0", someLibChanges.OldVersions.Single());
+            Assert.Equal("2.5.0", otherLibChanges.OldVersions.Single());
+
+            Assert.Equal("2.0.0", someLibChanges.NewVersions.Single());
+            Assert.Equal("3.5.0", otherLibChanges.NewVersions.Single());
+#else
+            Assert.Equal("3.0.0", someLibChanges.OldVersions.Single());
+            Assert.Empty(otherLibChanges.OldVersions);
+
+            Assert.Equal("2.0.0", someLibChanges.NewVersions.Single());
+            Assert.Equal("3.5.0", otherLibChanges.NewVersions.Single());
+#endif
+        }
+
+#if (NET5_0_OR_GREATER)
+
+        [Fact]
+        public void When_directory_packages_props_changes_without_dependant_projects_nothing_should_be_affected()
+        {
+            // Create a Directory.Package.props
+            var packageName = "Some.Library";
+            Repository
+                .CreateDirectoryPackageProps(b => b.AddPackageVersion(packageName, "2.0.0"));
+
+            // Create a project with a nuget dependency
+            var projectName = "InventoryManagement";
+            var msBuildProject = Repository.CreateCsProject(
+                projectName,
+                b => b.AddNuGetDependency(packageName));
+
+            msBuildProject
+                .CreateDirectoryPackageProps(true, b => b.AddPackageVersion(packageName, "1.0.0"));
+
+            // Commit so there are no changes
+            Repository.StageAndCommit();
+
+            var otherPackageName = "Other.Library";
+            Repository.UpdateDirectoryPackageProps(
+                b => b.AddPackageVersion(otherPackageName, "2.0.0"));
+
+            Assert.Single(AffectedSummary.ChangedPackages);
+            Assert.Empty(AffectedSummary.AffectedProjects);
+        }
+
+        [Fact]
+        public void With_nested_conditional_props_file_projects_should_still_be_affected()
+        {
+            var packageName = "Some.Library";
+            Repository
+                .CreateDirectoryPackageProps(b =>
+                {
+                    var itemGroup = b.AddItemGroup();
+                    itemGroup.Condition = "'$(TargetFramework)' == 'net5.0'";
+                    var item = itemGroup.AddItem("PackageVersion", packageName);
+                    item.AddMetadata("Version", "5.0.0", expressAsAttribute: true);
+                    
+                    itemGroup = b.AddItemGroup();
+                    itemGroup.Condition = "'$(TargetFramework)' == 'net6.0'";
+                    item = itemGroup.AddItem("PackageVersion", packageName);
+                    item.AddMetadata("Version", "6.0.0", expressAsAttribute: true);
+                });
+            
+            // Create a project with a nuget dependency
+            var projectName = "InventoryManagement";
+            var msBuildProject = Repository.CreateCsProject(
+                projectName,
+                b => b.AddNuGetDependency(packageName));
+
+            // Commit all so there are no changes
+            Repository.StageAndCommit();
+
+            msBuildProject
+                .CreateDirectoryPackageProps(true, b =>
+                {
+                    var itemGroup = b.AddItemGroup();
+                    itemGroup.Condition = "'$(TargetFramework)' == 'net5.0'";
+                    var item = itemGroup.AddItem("PackageVersion", packageName);
+                    item.AddMetadata("Version", "5.1.0", expressAsAttribute: true);
+                    
+                    itemGroup = b.AddItemGroup();
+                    itemGroup.Condition = "'$(TargetFramework)' == 'net6.0'";
+                    item = itemGroup.AddItem("PackageVersion", packageName);
+                    item.AddMetadata("Version", "6.1.0", expressAsAttribute: true);
+                });
+
+
+            Assert.Single(AffectedSummary.ChangedPackages);
+            Assert.Single(AffectedSummary.AffectedProjects);
+
+            var changedPackage = AffectedSummary.ChangedPackages.Single();
+            Assert.Equal(changedPackage.Name, packageName);
+            Assert.Equal(2, changedPackage.OldVersions.Count);
+            Assert.Equal(2, changedPackage.NewVersions.Count);
+            Assert.Equal(changedPackage.OldVersions, new []{"5.0.0", "6.0.0"});
+            Assert.Equal(changedPackage.NewVersions, new []{"5.1.0", "6.1.0"});            
+        }
+
+        [Fact]
+        public void When_nested_package_is_added_dependant_projects_should_be_affected()
+        {
+            // Create a Directory.Package.props
+            var packageName = "Some.Library";
+            Repository
+                .CreateDirectoryPackageProps(b => b.AddPackageVersion(packageName, "2.0.0"));
+
+            // Create a project with a nuget dependency
+            var projectName = "InventoryManagement";
+            var msBuildProject = Repository.CreateCsProject(
+                projectName,
+                b => b.AddNuGetDependency(packageName));
+
+            // Commit so there are no changes
+            Repository.StageAndCommit();
+
+            msBuildProject
+                .CreateDirectoryPackageProps(true, b => b.AddPackageVersion(packageName, "1.0.0"));
+
+            Assert.Single(AffectedSummary.FilesThatChanged);
+            Assert.Single(AffectedSummary.ChangedPackages);
+            Assert.Single(AffectedSummary.AffectedProjects);
+
+            var projectInfo = AffectedSummary.AffectedProjects.Single();
+            Assert.Equal(projectName, projectInfo.GetProjectName());
+            Assert.Equal(msBuildProject.FullPath, projectInfo.GetFullPath());
+            
+            var changedPackage = AffectedSummary.ChangedPackages.Single();
+            Assert.Equal(changedPackage.Name, packageName);
+            Assert.Equal(changedPackage.OldVersions.Single(), "2.0.0");
+            Assert.Equal(changedPackage.NewVersions.Single(), "1.0.0");
+        }
+
+        [Fact]
+        public void When_directory_packages_props_is_removed_dependant_projects_should_be_affected()
+        {
+            // Create a Directory.Package.props
+            var packageName = "Some.Library";
+            Repository
+                .CreateDirectoryPackageProps(b => b.AddPackageVersion(packageName, "1.0.0"));
+
+            // Create a project with a nuget dependency
+            var projectName = "InventoryManagement";
+            var msBuildProject = Repository.CreateCsProject(
+                projectName,
+                b => b.AddNuGetDependency(packageName));
+
+            msBuildProject
+                .CreateDirectoryPackageProps(true, b => b.AddPackageVersion(packageName, "2.0.0"));
+
+            // Commit so there are no changes
+            Repository.StageAndCommit();
+
+            msBuildProject.RemoveDirectoryPackageProps();
+
+            Assert.Single(AffectedSummary.FilesThatChanged);
+            Assert.Single(AffectedSummary.ChangedPackages);
+            Assert.Single(AffectedSummary.AffectedProjects);
+
+            var projectInfo = AffectedSummary.AffectedProjects.Single();
+            Assert.Equal(projectName, projectInfo.GetProjectName());
+            Assert.Equal(msBuildProject.FullPath, projectInfo.GetFullPath());
+
+            var changedPackage = AffectedSummary.ChangedPackages.Single();
+            Assert.Equal(changedPackage.Name, packageName);
+            Assert.Equal(changedPackage.OldVersions.Single(), "2.0.0");
+            Assert.Equal(changedPackage.NewVersions.Single(), "1.0.0");
+        }
+        
+        [Fact]
+        public void With_nested_conditional_props_file_projects_should_still_be_affected1()
+        {
+            // Create a Directory.Package.props
+            var packageName = "Some.Library";
+            Repository
+                .CreateDirectoryPackageProps(b => b.AddPackageVersion(packageName, "2.0.0"));
+
+            // Create a project with a nuget dependency
+            var projectName = "InventoryManagement";
+            var msBuildProject = Repository.CreateCsProject(
+                projectName,
+                b => b.AddNuGetDependency(packageName));
+
+            msBuildProject
+                .CreateDirectoryPackageProps(true, b => b.AddPackageVersion(packageName, "1.0.0"));
+    
+            // Commit so there are no changes
+            Repository.StageAndCommit();
+
+            Repository.UpdateDirectoryPackageProps(
+                b => b.AddPackageVersion(packageName, "2.1.0"));
+
+            msBuildProject
+                .UpdateDirectoryPackageProps(b => b.AddPackageVersion(packageName, "1.1.0"));
+
+            Assert.Equal(2, AffectedSummary.FilesThatChanged.Length);
+            Assert.Single(AffectedSummary.ChangedPackages);
+            Assert.Single(AffectedSummary.AffectedProjects);
+
+            var projectInfo = AffectedSummary.AffectedProjects.Single();
+            Assert.Equal(projectName, projectInfo.GetProjectName());
+            Assert.Equal(msBuildProject.FullPath, projectInfo.GetFullPath());
+            
+            var changedPackage = AffectedSummary.ChangedPackages.Single();
+            Assert.Equal(packageName, changedPackage.Name);
+            Assert.Equal("1.0.0", changedPackage.OldVersions.Single());
+            Assert.Equal("1.1.0", changedPackage.NewVersions.Single());      
+        }
+
+#endif // NET5_0_OR_GREATER
+
+    }
+}
+

--- a/test/DotnetAffected.Core.Tests/CentralPackageManagementDetectionTests.cs
+++ b/test/DotnetAffected.Core.Tests/CentralPackageManagementDetectionTests.cs
@@ -9,8 +9,7 @@ namespace DotnetAffected.Core.Tests
     /// <summary>
     /// Tests for detecting affected projects when central package management changes
     /// </summary>
-    public class CentralPackageManagementDetectionTests
-        : BaseDotnetAffectedTest
+    public class CentralPackageManagementDetectionTests : BaseDotnetAffectedTest
     {
         [Fact]
         public void When_package_is_updated_dependant_projects_should_be_affected()
@@ -251,10 +250,15 @@ namespace DotnetAffected.Core.Tests
 
             // Commit so there are no changes
             Repository.StageAndCommit();
-
+            
             Repository.RemoveDirectoryPackageProps();
+            msBuildProject.ItemGroups
+                .SelectMany(g => g.Items)
+                .Single(i => i.ElementName == "PackageReference" && i.Include == packageName)
+                .AddMetadata("Version", "1.1.0");
+            msBuildProject.Save();
 
-            Assert.Single(AffectedSummary.FilesThatChanged);
+            Assert.Equal(2, AffectedSummary.FilesThatChanged.Length);
             Assert.Single(AffectedSummary.ChangedPackages);
             Assert.Single(AffectedSummary.AffectedProjects);
 

--- a/test/DotnetAffected.Core.Tests/Utils/BaseDotnetAffectedTest.cs
+++ b/test/DotnetAffected.Core.Tests/Utils/BaseDotnetAffectedTest.cs
@@ -17,7 +17,7 @@ namespace DotnetAffected.Core.Tests
             });
         }
 
-        protected virtual AffectedOptions Options => new AffectedOptions(this.Repository.Path);
+        protected virtual AffectedOptions Options => new AffectedOptions(Repository.Path);
 
         protected virtual IChangesProvider ChangesProvider => new GitChangesProvider();
 

--- a/test/DotnetAffected.Testing.Utils/Repository/TemporaryRepository.cs
+++ b/test/DotnetAffected.Testing.Utils/Repository/TemporaryRepository.cs
@@ -7,23 +7,30 @@ namespace DotnetAffected.Testing.Utils
     {
         public TemporaryRepository()
         {
-            this.Directory = new TempWorkingDirectory();
+            Directory = new TempWorkingDirectory();
 
             // git init a repo at the path
-            Repository.Init(this.Path);
+            Repository.Init(Directory.Path);
 
             // open the repository
-            this.Repository = new Repository(this.Path);
+            Repository = new Repository(Directory.Path);
+
+            // We expose the path from a single place to maintain consistency across operating systems.
+            // E.G in OSX calling "System.IO.Path.GetTempPath" will return "/var/x/y/z" which we will
+            // supply to "Repository", however "Repository.Info.WorkingDirectory" will return "/private/var/x/y/z" which
+            // is the same but causes issues when comparing or evaluating.
+            Path = System.IO.Path.TrimEndingDirectorySeparator(Repository.Info.WorkingDirectory);
 
             // Create the first commit
-            this.Commit("Initial Commit");
+            Commit("Initial Commit");
         }
 
         public Repository Repository { get; }
 
-        public TempWorkingDirectory Directory { get; }
+        public string Path { get; }
 
-        public string Path => this.Directory.Path;
+        private TempWorkingDirectory Directory { get; }
+
 
         public Commit StageAndCommit(string message = null)
         {

--- a/test/DotnetAffected.Testing.Utils/Repository/TemporaryRepositoryExtensions.cs
+++ b/test/DotnetAffected.Testing.Utils/Repository/TemporaryRepositoryExtensions.cs
@@ -101,6 +101,18 @@ namespace DotnetAffected.Testing.Utils
             await File.WriteAllTextAsync(path, contents);
         }
 
+        public static async Task CreateTextFileAsync(
+            this TemporaryRepository repo,
+            ProjectRootElement project,
+            string path,
+            string contents)
+        {
+            path = Path.Combine(repo.Path, project.GetName(), path);
+            var file = File.CreateText(path);
+            await file.DisposeAsync();
+            await File.WriteAllTextAsync(path, contents);
+        }
+        
         /// <summary>
         /// Creates a tree of csproj with a total of <paramref name="totalProjects" />
         /// Each project will try to have <paramref name="childrenPerProject" /> without


### PR DESCRIPTION
This will properly load `Project` files that have import references.

The main feature is the introduction of a virtual file system for `Project` instances that will represent the file system for a specific point in time (i.e. for a commit)  

It will allow loading `Import` elements within a `Project` that reference files in the state they were in commit.

I refer to this feature as **Proper project evaluation**.  
The feature is supported in `Microsoft.Build` **16.10** and above.  
I.E `net 5.0` and onwards **but not in** `netcore 3.1`.

To better understand there is a unit test, **documented to details**, that describes the expected output between execution with **proper project evaluation** (net5 +) and one without it (3.1).
 
![image](https://user-images.githubusercontent.com/5377501/189516377-e29f38ed-c9b1-4e31-b34b-825e84d13fcf.png)

`InventoryManagement/Directory.Packages.props` has an `<Import>` reference to `Directory.Packages.props`.
```xml
<Project>
    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Packages.props))\Directory.Packages.props" />

    <ItemGroup>
        <PackageVersion Include="Some.Library" Version="3.0.0" />
    </ItemGroup>
</Project>
```

```cs
     
        [Fact]
        public void When_directory_packages_props_updates_dependant_projects_should_be_affected()
        {
            // Create a Directory.Package.props
            var packageName = "Some.Library";
            var otherPackageName = "Other.Library";
            Repository
                .CreateDirectoryPackageProps(b => b.AddPackageVersion(otherPackageName, "2.5.0"));


            // Create a project with a nuget dependency
            var projectName = "InventoryManagement";
            var msBuildProject = Repository.CreateCsProject(
                projectName,
                b => b.AddNuGetDependency(packageName));


            msBuildProject
                .CreateDirectoryPackageProps(true, b => b.AddPackageVersion(packageName, "3.0.0"));


            // Commit so there are no changes
            Repository.StageAndCommit();


            msBuildProject.RemoveDirectoryPackageProps();
            msBuildProject
                .CreateDirectoryPackageProps(true, b => b.AddPackageVersion(otherPackageName, "3.5.0"));
            
            Repository.RemoveDirectoryPackageProps();
            Repository.UpdateDirectoryPackageProps(b => b.AddPackageVersion(packageName, "2.0.0"));


            Assert.Equal(2, AffectedSummary.ChangedPackages.Length);
            Assert.Single(AffectedSummary.AffectedProjects);
            
            var someLibChanges = AffectedSummary.ChangedPackages.Single(c => c.Name == packageName);
            var otherLibChanges = AffectedSummary.ChangedPackages.Single(c => c.Name == otherPackageName);
            
#if (NET5_0_OR_GREATER)
            Assert.Equal("3.0.0", someLibChanges.OldVersions.Single());
            Assert.Equal("2.5.0", otherLibChanges.OldVersions.Single());


            Assert.Equal("2.0.0", someLibChanges.NewVersions.Single());
            Assert.Equal("3.5.0", otherLibChanges.NewVersions.Single());
#else
            Assert.Equal("3.0.0", someLibChanges.OldVersions.Single());
            Assert.Empty(otherLibChanges.OldVersions);


            Assert.Empty(someLibChanges.NewVersions);
            Assert.Equal("3.5.0", otherLibChanges.NewVersions.Single());
#endif
        }
```

Fixes #54
