### PR TITLE
Deduplicate affected projects

### DIFF
--- a/src/dotnet-affected/Infrastructure/OutputFormatterExecutor.cs
+++ b/src/dotnet-affected/Infrastructure/OutputFormatterExecutor.cs
@@ -32,7 +32,10 @@ namespace Affected.Cli
             var formatterDictionary = formatters
                 .ToDictionary(t => t, FindFormatter);
 
-            var allProjects = projects.ToList();
+            var allProjects = projects
+                .GroupBy(project => project.FilePath)
+                .Select(group => group.First())
+                .ToList();
 
             foreach (var (type, formatter) in formatterDictionary)
             {


### PR DESCRIPTION
It fixes the issue #63.

I believe that the `.proj` formatter doesn't contain this bug because of the following code:
https://github.com/leonardochaia/dotnet-affected/blob/b4e89f4c5af894741ac0db926cf6e8e391aada8a/src/dotnet-affected/Infrastructure/Formatters/TraversalProjectOutputFormatter.cs#L30-L34

Nevertheless, the number of affected projects should be unified for all formatters.

I run these changes for [this](https://github.com/bartlomiejgawel/dotnet-affected-bug) repo and got the following results:
```bash
DRY-RUN: WRITE affected.txt
DRY-RUN: CONTENTS:
DotnetAffected\DotnetAffected.FirstApp\DotnetAffected.FirstApp.csproj
DotnetAffected\DotnetAffected.Library\DotnetAffected.Library.csproj
DotnetAffected\DotnetAffected.SecondApp\DotnetAffected.SecondApp.csproj

DRY-RUN: WRITE affected.proj
DRY-RUN: CONTENTS:
<Project Sdk="Microsoft.Build.Traversal/3.0.3">
  <ItemGroup>
    <ProjectReference Include="DotnetAffected\DotnetAffected.FirstApp\DotnetAffected.FirstApp.csproj" />
    <ProjectReference Include="DotnetAffected\DotnetAffected.Library\DotnetAffected.Library.csproj" />
    <ProjectReference Include="DotnetAffected\DotnetAffected.SecondApp\DotnetAffected.SecondApp.csproj" />
  </ItemGroup>
</Project>
```