### PR TITLE
Added --exclude feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,10 +214,14 @@ dotnet affected --from chore/target-net7 --to main
 ```
 
 ## Output Formatting
+The `--format` command line option can be used to choose which output formats will be used.
 
-dotnet-affected currently supports outputting Traversal SDK project files and plain text list of changed and affected
-projects. The `--format` option can be used to choose which format to output.
+dotnet-affected currently supports following **format options**:
+- `traversal`: Traversal SDK project file.
+- `text`: Plain text file containing all affected project paths.
+- `json`: JSON file containing all affected project names and paths.
 
+Example:
 ```text
 $ dotnet affected -v --format text
 Discovering projects from /home/lchaia/dev/dotnet-affected
@@ -242,13 +246,13 @@ $ cat affected.txt                                                              
 /home/lchaia/dev/dotnet-affected/src/dotnet-affected.Tests/dotnet-affected.Tests.csproj
 ```
 
-## Multiple Output Formats
+### Multiple Output Formats
 
-Multiple formats can be generated at the same time by separating them with spaces. This is quite useful in CI to
-build/test and also get the list of projects to deploy.
+This tool supports generating multiple output files by providing space-seperated format options to the `--format` flag.
 
+Example:
 ```text
-$ dotnet affected -v --format text traversal
+$ dotnet affected -v --format text traversal json
 Discovering projects from /home/lchaia/dev/dotnet-affected
 Building Dependency Graph
 Built Graph with 8 Projects in 0.39s
@@ -264,6 +268,7 @@ Name                   Path
 dotnet-affected.Tests  /home/lchaia/dev/dotnet-affected/src/dotnet-affected.Tests/dotnet-affected.Tests.csproj
 WRITE: /home/lchaia/dev/dotnet-affected/affected.txt
 WRITE: /home/lchaia/dev/dotnet-affected/affected.proj
+WRITE: /home/lchaia/dev/dotnet-affected/affected.json
 ```
 
 ## Continuous Integration

--- a/README.md
+++ b/README.md
@@ -271,6 +271,17 @@ WRITE: /home/lchaia/dev/dotnet-affected/affected.proj
 WRITE: /home/lchaia/dev/dotnet-affected/affected.json
 ```
 
+## Excluding Projects
+The `--exclude` command line option can be used to exclude projects which name match the provided regular expression.
+
+Usage: `--exclude [RegularExpression]`
+
+Examples:
+- `dotnet-affected --exclude Test` Filters out all projects where the string 'Test' is in the project name.
+- `dotnet-affected --exclude "dotnet-affected\.Tests"` Filters out all projects where the string 'dotnet-affected.Tests' is in the project name.
+
+Note: If you are using special characters in your regular expression, for example: `., +, *, ?, ^, $, (, ), [, ], {, }, |, \.`, put the regex into quotation marks. Otherwise the command line interpreter could try to interpret them.
+
 ## Continuous Integration
 
 For usage in CI, it's recommended to use the `--from` and `--to` options with the environment variables provided by your

--- a/src/dotnet-affected/Commands/AffectedGlobalOptions.cs
+++ b/src/dotnet-affected/Commands/AffectedGlobalOptions.cs
@@ -55,7 +55,7 @@ namespace Affected.Cli.Commands
                 "--to"
             })
         {
-            this.Description = "A branch or commit to compare against --from";
+            this.Description = "A branch or commit to compare against --from.";
 
             this.AddValidator(optionResult =>
             {

--- a/src/dotnet-affected/Commands/AffectedRootCommand.cs
+++ b/src/dotnet-affected/Commands/AffectedRootCommand.cs
@@ -13,7 +13,9 @@ namespace Affected.Cli.Commands
         public static readonly OutputNameOption OutputNameOption = new();
 
         public AffectedRootCommand()
-            : base("Determines which projects are affected by a set of changes.")
+            : base("Determines which projects are affected by a set of changes.\n" +
+                   "For examples and detailed descriptions see: " +
+                   "https://github.com/leonardochaia/dotnet-affected/blob/main/README.md")
         {
             this.Name = "dotnet-affected";
             this.AddCommand(new DescribeCommand());
@@ -71,7 +73,8 @@ namespace Affected.Cli.Commands
                 "--format", "-f"
             })
         {
-            this.Description = "Space separated list of formatters to write the output.";
+            this.Description = "Space-seperated output file formats. Possible values: <traversal, text, json>.";
+            
             this.SetDefaultValue(new[]
             {
                 "traversal"
@@ -88,7 +91,7 @@ namespace Affected.Cli.Commands
                 "--dry-run"
             })
         {
-            this.Description = "Doesn't create files, outputs to stdout instead.";
+            this.Description = "Only output to stdout. No output files will be created.";
             this.SetDefaultValue(false);
         }
     }
@@ -101,8 +104,8 @@ namespace Affected.Cli.Commands
                 "--output-dir"
             })
         {
-            this.Description = "The directory where the output file(s) will be generated\n" +
-                               "If relative, it's relative to the --repository-path";
+            this.Description = "The directory where the output file(s) will be generated.\n" +
+                               "Relative paths will be based on --repository-path.";
         }
     }
 
@@ -114,8 +117,8 @@ namespace Affected.Cli.Commands
                 "--output-name"
             })
         {
-            this.Description = "The name for the file to create for each format.\n" +
-                               "Format extension is appended to this name.";
+            this.Description = "The filename to create.\n" +
+                               "Format file extensions will be appended.";
             this.SetDefaultValue("affected");
         }
     }

--- a/src/dotnet-affected/Commands/AffectedRootCommand.cs
+++ b/src/dotnet-affected/Commands/AffectedRootCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Affected.Cli.Views;
+using Affected.Cli.Extensions;
 using System.CommandLine;
 using System.CommandLine.Rendering;
 using System.Linq;
@@ -11,6 +12,7 @@ namespace Affected.Cli.Commands
         public static readonly DryRunOption DryRunOption = new();
         public static readonly OutputDirOption OutputDirOption = new();
         public static readonly OutputNameOption OutputNameOption = new();
+        public static readonly ExcludePatternOption ExcludePatternOption = new();
 
         public AffectedRootCommand()
             : base("Determines which projects are affected by a set of changes.\n" +
@@ -31,6 +33,7 @@ namespace Affected.Cli.Commands
             this.AddOption(DryRunOption);
             this.AddOption(OutputDirOption);
             this.AddOption(OutputNameOption);
+            this.AddOption(ExcludePatternOption);
 
             this.SetHandler(async ctx =>
             {
@@ -44,14 +47,15 @@ namespace Affected.Cli.Commands
                     var infoView = new AffectedInfoView(summary);
                     console.Append(infoView);
                 }
-
+                
+                // Generate output using formatters
+                var outputOptions = ctx.GetAffectedCommandOutputOptions(options);
+                
                 var allProjects = summary
                     .ProjectsWithChangedFiles
                     .Concat(summary.AffectedProjects)
-                    .Select(p => new ProjectInfo(p));
-
-                // Generate output using formatters
-                var outputOptions = ctx.GetAffectedCommandOutputOptions(options);
+                    .Select(p => new ProjectInfo(p))
+                    .RegexExclude(project => project.Name, outputOptions.ExcludePattern);
 
                 var formatterExecutor = new OutputFormatterExecutor(console);
                 await formatterExecutor.Execute(
@@ -120,6 +124,18 @@ namespace Affected.Cli.Commands
             this.Description = "The filename to create.\n" +
                                "Format file extensions will be appended.";
             this.SetDefaultValue("affected");
+        }
+    }
+    
+    internal sealed class ExcludePatternOption : Option<string>
+    {
+        public ExcludePatternOption()
+            : base(new[]
+            {
+                "--exclude"
+            })
+        {
+            this.Description = "A regex pattern which projects names to exclude.";
         }
     }
 }

--- a/src/dotnet-affected/Commands/Binding/AffectedCommandOutputOptions.cs
+++ b/src/dotnet-affected/Commands/Binding/AffectedCommandOutputOptions.cs
@@ -11,17 +11,20 @@ namespace Affected.Cli.Commands
             string repositoryPath,
             string? outputDir,
             string outputName,
+            string? excludePattern,
             string[] formatters,
             bool dryRun)
         {
             OutputDir = DetermineOutputDir(repositoryPath, outputDir);
             OutputName = outputName;
+            ExcludePattern = excludePattern;
             Formatters = formatters;
             DryRun = dryRun;
         }
 
         public string OutputDir { get; }
         public string OutputName { get; }
+        public string? ExcludePattern { get; }
         public string[] Formatters { get; }
         public bool DryRun { get; }
 

--- a/src/dotnet-affected/Commands/Binding/AffectedCommandOutputOptionsBinder.cs
+++ b/src/dotnet-affected/Commands/Binding/AffectedCommandOutputOptionsBinder.cs
@@ -19,6 +19,7 @@ namespace Affected.Cli.Commands
                 _options.RepositoryPath,
                 result.GetValueForOption(AffectedRootCommand.OutputDirOption)!,
                 result.GetValueForOption(AffectedRootCommand.OutputNameOption)!,
+                result.GetValueForOption(AffectedRootCommand.ExcludePatternOption)!,
                 result.GetValueForOption(AffectedRootCommand.FormatOption)!,
                 result.GetValueForOption(AffectedRootCommand.DryRunOption)
             );

--- a/src/dotnet-affected/Extensions/LinqExtensions.cs
+++ b/src/dotnet-affected/Extensions/LinqExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text.RegularExpressions;
+
+namespace Affected.Cli.Extensions
+{
+    /// <summary>
+    /// Extension methods over <see cref="System.Linq"/>.
+    /// </summary>
+    public static class LinqExtensions
+    {
+        /// <summary>
+        /// Filters out projects where the project name matches the <paramref name="regexPattern"/> provided.
+        /// <param name="source">The Enumerable to filter in. Must be of type IProjectInfo</param>
+        /// <param name="propertySelector">The property to filter</param>
+        /// <param name="regexPattern">The regex pattern to match for. If provided null, the <paramref name="source"/> Enumerable will be returned</param>
+        /// </summary>
+        public static IEnumerable<T> RegexExclude<T>(this IEnumerable<T> source, Func<T,string> propertySelector, string? regexPattern)
+        {
+            if (regexPattern == null) return source;
+
+            var regex = new Regex(regexPattern);
+            return source.Where(obj => !regex.IsMatch(propertySelector.Invoke(obj)));
+        }
+    }
+}


### PR DESCRIPTION
I was missing an option to exclude projects.
This is especially useful if you want to build only the affected projects, but no projects which are including tests.

To accomplish this, I added the command line option --exclude, where you can specify a regulary expression, which filters out all project names that are matching this expression.

