### PR TITLE
feat: exclude projects

### DIFF
--- a/src/DotnetAffected.Abstractions/AffectedSummary.cs
+++ b/src/DotnetAffected.Abstractions/AffectedSummary.cs
@@ -13,16 +13,19 @@ namespace DotnetAffected.Abstractions
         /// <param name="filesThatChanged"></param>
         /// <param name="projectsWithChangedFiles"></param>
         /// <param name="affectedProjects"></param>
+        /// <param name="excludedProjects"></param>
         /// <param name="changedPackages"></param>
         public AffectedSummary(
             string[] filesThatChanged,
             ProjectGraphNode[] projectsWithChangedFiles,
             ProjectGraphNode[] affectedProjects,
+            ProjectGraphNode[] excludedProjects,
             PackageChange[] changedPackages)
         {
             FilesThatChanged = filesThatChanged;
             ProjectsWithChangedFiles = projectsWithChangedFiles;
             AffectedProjects = affectedProjects;
+            ExcludedProjects = excludedProjects;
             ChangedPackages = changedPackages;
         }
 
@@ -40,6 +43,11 @@ namespace DotnetAffected.Abstractions
         /// Gets a list of projects that are affected by the <see cref="FilesThatChanged"/>.
         /// </summary>
         public ProjectGraphNode[] AffectedProjects { get; }
+
+        /// <summary>
+        /// Gets a list of projects that had changes or were affected but were excluded from discovery.
+        /// </summary>
+        public ProjectGraphNode[] ExcludedProjects { get; }
 
         /// <summary>
         /// Gets the list of packages that changed.

--- a/src/DotnetAffected.Core/AffectedOptions.cs
+++ b/src/DotnetAffected.Core/AffectedOptions.cs
@@ -16,16 +16,19 @@ namespace DotnetAffected.Core
         /// <param name="solutionPath"></param>
         /// <param name="fromRef"></param>
         /// <param name="toRef"></param>
+        /// <param name="exclusionRegex"></param>
         public AffectedOptions(
             string? repositoryPath = null,
             string? solutionPath = null,
             string? fromRef = null,
-            string? toRef = null)
+            string? toRef = null,
+            string? exclusionRegex = null)
         {
             RepositoryPath = DetermineRepositoryPath(repositoryPath, solutionPath);
             SolutionPath = solutionPath;
             FromRef = fromRef ?? string.Empty;
             ToRef = toRef ?? string.Empty;
+            ExclusionRegex = exclusionRegex;
         }
 
         /// <summary>
@@ -47,6 +50,11 @@ namespace DotnetAffected.Core
         /// Gets the reference up to which changes will be compared from.
         /// </summary>
         public string ToRef { get; }
+
+        /// <summary>
+        /// Gets the regular expression to use for excluding projects.
+        /// </summary>
+        public string? ExclusionRegex { get; }
 
         private static string DetermineRepositoryPath(string? repositoryPath, string? solutionPath)
         {

--- a/src/dotnet-affected/Commands/AffectedGlobalOptions.cs
+++ b/src/dotnet-affected/Commands/AffectedGlobalOptions.cs
@@ -45,6 +45,13 @@ namespace Affected.Cli.Commands
             description: "A branch or commit to compare against --to.");
 
         public static readonly ToOption ToOption = new(FromOption);
+
+        public static readonly Option<string> ExclusionRegexOption = new(
+            new[]
+            {
+                "--exclude", "-e"
+            },
+            description: "A dotnet Regular Expression used to exclude discovered and affected projects.");
     }
 
     internal sealed class ToOption : Option<string>

--- a/src/dotnet-affected/Commands/AffectedRootCommand.cs
+++ b/src/dotnet-affected/Commands/AffectedRootCommand.cs
@@ -26,6 +26,7 @@ namespace Affected.Cli.Commands
             this.AddGlobalOption(AffectedGlobalOptions.AssumeChangesOption);
             this.AddGlobalOption(AffectedGlobalOptions.FromOption);
             this.AddGlobalOption(AffectedGlobalOptions.ToOption);
+            this.AddGlobalOption(AffectedGlobalOptions.ExclusionRegexOption);
 
             this.AddOption(FormatOption);
             this.AddOption(DryRunOption);
@@ -74,7 +75,7 @@ namespace Affected.Cli.Commands
             })
         {
             this.Description = "Space-seperated output file formats. Possible values: <traversal, text, json>.";
-            
+
             this.SetDefaultValue(new[]
             {
                 "traversal"

--- a/src/dotnet-affected/Commands/Binding/AffectedOptionsBinder.cs
+++ b/src/dotnet-affected/Commands/Binding/AffectedOptionsBinder.cs
@@ -15,7 +15,8 @@ namespace Affected.Cli.Commands
                 parseResult.GetValueForOption(AffectedGlobalOptions.RepositoryPathOptions),
                 parseResult.GetValueForOption(AffectedGlobalOptions.SolutionPathOption),
                 parseResult.GetValueForOption(AffectedGlobalOptions.FromOption),
-                parseResult.GetValueForOption(AffectedGlobalOptions.ToOption)
+                parseResult.GetValueForOption(AffectedGlobalOptions.ToOption),
+                parseResult.GetValueForOption(AffectedGlobalOptions.ExclusionRegexOption)
             );
         }
     }

--- a/src/dotnet-affected/Views/AffectedInfoView.cs
+++ b/src/dotnet-affected/Views/AffectedInfoView.cs
@@ -12,6 +12,7 @@ namespace Affected.Cli.Views
                                 $"referenced by {summary.ProjectsWithChangedFiles.Count()} projects"));
             Add(new ContentView($"{summary.ChangedPackages.Count()} NuGet Packages have changed"));
             Add(new ContentView($"{summary.AffectedProjects.Count()} projects are affected by these changes"));
+            Add(new ContentView($"{summary.ExcludedProjects.Count()} projects were excluded"));
 
             Add(new WithChangesAndAffectedView(summary));
         }

--- a/test/DotnetAffected.Core.Tests/ProjectExclusionTests.cs
+++ b/test/DotnetAffected.Core.Tests/ProjectExclusionTests.cs
@@ -38,6 +38,8 @@ namespace DotnetAffected.Core.Tests
 
             Assert.Empty(AffectedSummary.ProjectsWithChangedFiles);
             Assert.Empty(AffectedSummary.AffectedProjects);
+
+            Assert.Single(AffectedSummary.ExcludedProjects);
         }
 
         [Fact]
@@ -53,8 +55,10 @@ namespace DotnetAffected.Core.Tests
                 dependantProjectName,
                 p => p.AddProjectDependency(msBuildProject.FullPath));
 
-            this.Repository.CreateCsProject("InventoryManagement");
-            this.Repository.CreateCsProject("InventoryManagement.Api");
+            // Create projects to be excluded
+            var otherProject = this.Repository.CreateCsProject("InventoryManagement");
+            this.Repository.CreateCsProject("InventoryManagement.Api",
+                p => p.AddProjectDependency(otherProject.FullPath));
             this.Repository.CreateCsProject("InventoryManagement.Tests");
 
             // Commit so there are no changes
@@ -63,6 +67,10 @@ namespace DotnetAffected.Core.Tests
             // Create changes in the first project
             var targetFilePath = Path.Combine(projectName, "file.cs");
             await this.Repository.CreateTextFileAsync(targetFilePath, "// Initial content");
+
+            // Create changes in the excluded project
+            var excludedFilePath = Path.Combine(otherProject.GetName(), "excluded_file.cs");
+            await this.Repository.CreateTextFileAsync(excludedFilePath, "// Initial content");
 
             Assert.Single(AffectedSummary.ProjectsWithChangedFiles);
             Assert.Single(AffectedSummary.AffectedProjects);
@@ -74,6 +82,46 @@ namespace DotnetAffected.Core.Tests
             var affectedProject = AffectedSummary.AffectedProjects.Single();
             Assert.Equal(dependantProjectName, affectedProject.GetProjectName());
             Assert.Equal(dependantMsBuildProject.FullPath, affectedProject.GetFullPath());
+
+            Assert.Single(AffectedSummary.ExcludedProjects);
+        }
+
+        [Fact]
+        public async Task When_exclusion_regex_is_present_affected_projects_should_be_excluded()
+        {
+            // Create a project
+            var projectName = "PurchasingManagement";
+            var msBuildProject = this.Repository.CreateCsProject(projectName);
+
+            // Create another project that depends on the first one
+            var dependantProjectName = "InventoryManagement";
+            var dependantMsBuildProject = this.Repository.CreateCsProject(
+                dependantProjectName,
+                p => p.AddProjectDependency(msBuildProject.FullPath));
+
+            // Other project to be excluded by discovery
+            var otherProjectName = "InventoryManagement.Api";
+            var otherProject = this.Repository.CreateCsProject(otherProjectName);
+            // Commit so there are no changes
+            this.Repository.StageAndCommit();
+
+            // Create changes in the first project
+            var targetFilePath = Path.Combine(projectName, "file.cs");
+            await this.Repository.CreateTextFileAsync(targetFilePath, "// Initial content");
+
+            // Create changes in the other project
+            var otherTargetFilePath = Path.Combine(otherProjectName, "other_file.cs");
+            await this.Repository.CreateTextFileAsync(otherTargetFilePath, "// Initial content");
+
+            Assert.Single(AffectedSummary.ProjectsWithChangedFiles);
+            Assert.Empty(AffectedSummary.AffectedProjects);
+
+            var changedProject = AffectedSummary.ProjectsWithChangedFiles.Single();
+            Assert.Equal(projectName, changedProject.GetProjectName());
+            Assert.Equal(msBuildProject.FullPath, changedProject.GetFullPath());
+
+            // Both discovered and affected projects should be excluded
+            Assert.Equal(2, AffectedSummary.ExcludedProjects.Length);
         }
     }
 }

--- a/test/DotnetAffected.Core.Tests/ProjectExclusionTests.cs
+++ b/test/DotnetAffected.Core.Tests/ProjectExclusionTests.cs
@@ -1,0 +1,79 @@
+﻿using DotnetAffected.Testing.Utils;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DotnetAffected.Core.Tests
+{
+    /// <summary>
+    /// Tests that ensures that the exclusion regex pattern
+    /// is applied for excluding projects.
+    /// </summary>
+    public class ProjectExclusionTests
+        : BaseDotnetAffectedTest
+    {
+        protected override AffectedOptions Options =>
+            new AffectedOptions(this.Repository.Path, exclusionRegex: ".Inventory.");
+
+        [Fact]
+        public async Task When_exclusion_regex_is_present_matching_projects_should_be_excluded()
+        {
+            // Create a project
+            var projectName = "InventoryManagement";
+            var msBuildProject = this.Repository.CreateCsProject(projectName);
+
+            // Create another project that depends on the first one
+            var dependantProjectName = "InventoryManagement.Tests";
+            var dependantMsBuildProject = this.Repository.CreateCsProject(
+                dependantProjectName,
+                p => p.AddProjectDependency(msBuildProject.FullPath));
+
+            // Commit so there are no changes
+            this.Repository.StageAndCommit();
+
+            // Create changes in the first project
+            var targetFilePath = Path.Combine(projectName, "file.cs");
+            await this.Repository.CreateTextFileAsync(targetFilePath, "// Initial content");
+
+            Assert.Empty(AffectedSummary.ProjectsWithChangedFiles);
+            Assert.Empty(AffectedSummary.AffectedProjects);
+        }
+
+        [Fact]
+        public async Task When_exclusion_regex_is_present_only_matching_projects_should_be_excluded()
+        {
+            // Create a project
+            var projectName = "PurchasingManagement";
+            var msBuildProject = this.Repository.CreateCsProject(projectName);
+
+            // Create another project that depends on the first one
+            var dependantProjectName = "PurchasingManagement.Tests";
+            var dependantMsBuildProject = this.Repository.CreateCsProject(
+                dependantProjectName,
+                p => p.AddProjectDependency(msBuildProject.FullPath));
+
+            this.Repository.CreateCsProject("InventoryManagement");
+            this.Repository.CreateCsProject("InventoryManagement.Api");
+            this.Repository.CreateCsProject("InventoryManagement.Tests");
+
+            // Commit so there are no changes
+            this.Repository.StageAndCommit();
+
+            // Create changes in the first project
+            var targetFilePath = Path.Combine(projectName, "file.cs");
+            await this.Repository.CreateTextFileAsync(targetFilePath, "// Initial content");
+
+            Assert.Single(AffectedSummary.ProjectsWithChangedFiles);
+            Assert.Single(AffectedSummary.AffectedProjects);
+
+            var changedProject = AffectedSummary.ProjectsWithChangedFiles.Single();
+            Assert.Equal(projectName, changedProject.GetProjectName());
+            Assert.Equal(msBuildProject.FullPath, changedProject.GetFullPath());
+
+            var affectedProject = AffectedSummary.AffectedProjects.Single();
+            Assert.Equal(dependantProjectName, affectedProject.GetProjectName());
+            Assert.Equal(dependantMsBuildProject.FullPath, affectedProject.GetFullPath());
+        }
+    }
+}

--- a/test/dotnet-affected.Tests/AffectedCommandTests.cs
+++ b/test/dotnet-affected.Tests/AffectedCommandTests.cs
@@ -101,5 +101,26 @@ namespace Affected.Cli.Tests
 
             Assert.Contains($"No affected projects where found for the current changes", output);
         }
+
+        [Fact]
+        public async Task When_any_changes_using_exclusion_should_exclude_projects()
+        {
+            // Create a project
+            var projectName = "InventoryManagement";
+            var msBuildProject = this.Repository.CreateCsProject(projectName);
+
+            // Create projects to exclude
+            this.Repository.CreateCsProject("PurchasingManagement");
+            this.Repository.CreateFsProject("PurchasingManagement.Api");
+            this.Repository.CreateVbProject("PurchasingManagement.Api2");
+
+            var (output, exitCode) =
+                await this.InvokeAsync($"-p {Repository.Path} --dry-run --verbose --exclude .Purchasing.");
+
+            Assert.Equal(0, exitCode);
+
+            Assert.Contains($"Include=\"{msBuildProject.FullPath}\"", output);
+            Assert.DoesNotContain($"PurchasingManagement", output);
+        }
     }
 }

--- a/test/dotnet-affected.Tests/AffectedCommandTests.cs
+++ b/test/dotnet-affected.Tests/AffectedCommandTests.cs
@@ -121,6 +121,8 @@ namespace Affected.Cli.Tests
 
             Assert.Contains($"Include=\"{msBuildProject.FullPath}\"", output);
             Assert.DoesNotContain($"PurchasingManagement", output);
+
+            Assert.Contains($"3 projects were excluded", output);
         }
     }
 }


### PR DESCRIPTION
Adds project exclusion to core and CLI.

Exclusion uses dotnet regular expressions, and works for changed projects and also affected projects.