### PR TITLE
Update Microsoft.Build.Traversal sdk version to 4.1.0

### DIFF
--- a/src/dotnet-affected/Infrastructure/Formatters/TraversalProjectOutputFormatter.cs
+++ b/src/dotnet-affected/Infrastructure/Formatters/TraversalProjectOutputFormatter.cs
@@ -15,7 +15,7 @@ namespace Affected.Cli.Formatters
 
         public Task<string> Format(IEnumerable<IProjectInfo> projects)
         {
-            var projectRootElement = @"<Project Sdk=""Microsoft.Build.Traversal/3.0.3""></Project>";
+            var projectRootElement = @"<Project Sdk=""Microsoft.Build.Traversal/4.1.0""></Project>";
             var stringReader = new StringReader(projectRootElement);
             var xmlReader = new XmlTextReader(stringReader);
             var root = ProjectRootElement.Create(xmlReader);

--- a/test/dotnet-affected.Tests/Formatters/TraversalFormatterTests.cs
+++ b/test/dotnet-affected.Tests/Formatters/TraversalFormatterTests.cs
@@ -21,7 +21,7 @@ namespace Affected.Cli.Tests.Formatters
             var output = await formatter.Format(projects);
 
             CustomAssertions.LineSequenceEquals(output,
-                l => Assert.Contains("Microsoft.Build.Traversal/3.0.3", l),
+                l => Assert.Contains("Microsoft.Build.Traversal/4.1.0", l),
                 l => Assert.Contains("ItemGroup", l),
                 l => Assert.Contains(projectPath, l),
                 l => Assert.Contains("ItemGroup", l),
@@ -44,7 +44,7 @@ namespace Affected.Cli.Tests.Formatters
             var output = await formatter.Format(projects);
 
             CustomAssertions.LineSequenceEquals(output,
-                l => Assert.Contains("Microsoft.Build.Traversal/3.0.3", l),
+                l => Assert.Contains("Microsoft.Build.Traversal/4.1.0", l),
                 l => Assert.Contains("ItemGroup", l),
                 l => Assert.Contains(secondProjectPath, l),
                 l => Assert.Contains(firstProjectPath, l),


### PR DESCRIPTION
[Microsoft.Build.Traversal.4.0.0](https://github.com/microsoft/MSBuildSdks/releases/tag/Microsoft.Build.Traversal.4.0.0) added an ability to "to skip projects dynamically in Traversal projects and Visual Studio solution files" that is required for us.

Let's update sdk version to the latest
