### PR TITLE
fix(predictions): normalize paths outside of project dir

### DIFF
--- a/src/DotnetAffected.Core/Prediction/ProjectInputFilesCollector.cs
+++ b/src/DotnetAffected.Core/Prediction/ProjectInputFilesCollector.cs
@@ -25,7 +25,7 @@ namespace DotnetAffected.Core
             // Make the path absolute if needed.
             if (!Path.IsPathRooted(path))
             {
-                path = Path.GetFullPath(Path.Combine(projectInstance.Directory, path));
+                path = Path.Combine(projectInstance.Directory, path);
             }
             else if (!path.StartsWith(_repositoryPath))
             {
@@ -33,7 +33,7 @@ namespace DotnetAffected.Core
                 return;
             }
 
-            this.AllFiles.Add(path);
+            this.AllFiles.Add(Path.GetFullPath(path));
         }
 
         public void AddInputDirectory(string path, ProjectInstance projectInstance, string predictorName)


### PR DESCRIPTION
dotnet-affected works by comparing the output of `git diff` with the output of MSBuild.Predictions.
Basically, it needs to match the files that have changed with the files that are owned by each MSBuild Project.

For the comparison to works, paths must be normalized, we use `Path.GetFullPath` to do so.

This pr fixes the normalization of referencing paths outside of the project directory. The normalization was being done for relative paths only, this PR takes care of fixing it.

Fixes #93 