### PR TITLE
feat(discovery): supports discovering projects from MSBuild Project files (i.e traversal SDK)

### DIFF
--- a/src/DotnetAffected.Abstractions/IDiscoveryOptions.cs
+++ b/src/DotnetAffected.Abstractions/IDiscoveryOptions.cs
@@ -11,8 +11,9 @@
         string RepositoryPath { get; }
 
         /// <summary>
-        /// Gets the path to the solution file, if any.
+        /// Gets the path to a filtering file, if any.
+        /// This could be any file that the inner <see cref="IProjectDiscoverer"/> supports.
         /// </summary>
-        string? SolutionPath { get; }
+        string? FilterFilePath { get; }
     }
 }

--- a/src/DotnetAffected.Core/AffectedOptions.cs
+++ b/src/DotnetAffected.Core/AffectedOptions.cs
@@ -13,19 +13,19 @@ namespace DotnetAffected.Core
         /// Creates a new instance of <see cref="AffectedOptions"/>.
         /// </summary>
         /// <param name="repositoryPath">Will default to <see cref="Environment.CurrentDirectory"/> if not provided</param>
-        /// <param name="solutionPath"></param>
+        /// <param name="filterFilePath"></param>
         /// <param name="fromRef"></param>
         /// <param name="toRef"></param>
         /// <param name="exclusionRegex"></param>
         public AffectedOptions(
             string? repositoryPath = null,
-            string? solutionPath = null,
+            string? filterFilePath = null,
             string? fromRef = null,
             string? toRef = null,
             string? exclusionRegex = null)
         {
-            RepositoryPath = DetermineRepositoryPath(repositoryPath, solutionPath);
-            SolutionPath = solutionPath;
+            RepositoryPath = DetermineRepositoryPath(repositoryPath, filterFilePath);
+            FilterFilePath = filterFilePath;
             FromRef = fromRef ?? string.Empty;
             ToRef = toRef ?? string.Empty;
             ExclusionRegex = exclusionRegex;
@@ -37,9 +37,11 @@ namespace DotnetAffected.Core
         public string RepositoryPath { get; }
 
         /// <summary>
-        /// Gets the path to the solution file, if any.
+        /// Gets the path to the filter file, if any.
+        /// This could be a solution file, or any other file supported by the
+        /// <see cref="IProjectDiscoverer"/> implementations.
         /// </summary>
-        public string? SolutionPath { get; }
+        public string? FilterFilePath { get; }
 
         /// <summary>
         /// Gets the reference from which to compare changes to.
@@ -56,7 +58,7 @@ namespace DotnetAffected.Core
         /// </summary>
         public string? ExclusionRegex { get; }
 
-        private static string DetermineRepositoryPath(string? repositoryPath, string? solutionPath)
+        private static string DetermineRepositoryPath(string? repositoryPath, string? filterfilePath)
         {
             // the argument takes precedence.
             if (!string.IsNullOrWhiteSpace(repositoryPath))
@@ -65,20 +67,20 @@ namespace DotnetAffected.Core
             }
 
             // if no arguments, then use current directory
-            if (string.IsNullOrWhiteSpace(solutionPath))
+            if (string.IsNullOrWhiteSpace(filterfilePath))
             {
                 return Environment.CurrentDirectory;
             }
 
-            // When using solution, and no path specified, assume the solution's directory
-            var solutionDirectory = Path.GetDirectoryName(solutionPath);
-            if (string.IsNullOrWhiteSpace(solutionDirectory))
+            // When using a filter file, and no path specified, assume the filter file's directory
+            var filterFileDirectory = Path.GetDirectoryName(filterfilePath);
+            if (string.IsNullOrWhiteSpace(filterFileDirectory))
             {
                 throw new InvalidOperationException(
-                    $"Failed to determine directory from solution path {solutionPath}");
+                    $"Failed to determine directory from filter file path path. Ensure the path exists: {filterfilePath}");
             }
 
-            return solutionDirectory;
+            return filterFileDirectory;
         }
     }
 }

--- a/src/DotnetAffected.Core/ProjectDiscovery/MSBuildProjectDiscoverer.cs
+++ b/src/DotnetAffected.Core/ProjectDiscovery/MSBuildProjectDiscoverer.cs
@@ -1,0 +1,35 @@
+﻿using DotnetAffected.Abstractions;
+using Microsoft.Build.Evaluation;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace DotnetAffected.Core
+{
+    /// <summary>
+    /// Discovers projects based off the provided <see cref="Project"/>.
+    /// </summary>
+    internal class MSBuildProjectDiscoverer : IProjectDiscoverer
+    {
+        public IEnumerable<string> DiscoverProjects(IDiscoveryOptions options)
+        {
+            var traversalProjectPath = options.FilterFilePath;
+            if (string.IsNullOrEmpty(traversalProjectPath) || !traversalProjectPath.EndsWith(".proj"))
+            {
+                throw new InvalidOperationException($"{traversalProjectPath} should be a .proj file");
+            }
+
+            var traversalProjectDirectory = Path.GetDirectoryName(traversalProjectPath);
+            var traversalProject = new Project(traversalProjectPath);
+            
+            return traversalProject
+                .GetItems("ProjectReference")
+                .Select(i => i.EvaluatedInclude)
+                .Select(p=> Path.IsPathRooted(p) ? p : Path.Join(traversalProjectDirectory, p))
+                .Select(Path.GetFullPath)
+                .Distinct()
+                .ToArray();
+        }
+    }
+}

--- a/src/DotnetAffected.Core/ProjectDiscovery/ProjectDiscoveryManager.cs
+++ b/src/DotnetAffected.Core/ProjectDiscovery/ProjectDiscoveryManager.cs
@@ -1,0 +1,26 @@
+﻿using DotnetAffected.Abstractions;
+using System;
+using System.Collections.Generic;
+
+namespace DotnetAffected.Core
+{
+    internal class ProjectDiscoveryManager : IProjectDiscoverer
+    {
+        public IEnumerable<string> DiscoverProjects(IDiscoveryOptions options)
+        {
+            // Whe no filtering file is provided, discover from file system.
+            if (options.FilterFilePath == null)
+            {
+                return new DirectoryProjectDiscoverer().DiscoverProjects(options);
+            }
+
+            // When a filtering file is provided, use an specific discoverer based on its path.
+            if (options.FilterFilePath.EndsWith(".sln"))
+            {
+                return new SolutionFileProjectDiscoverer().DiscoverProjects(options);
+            }
+
+            throw new NotImplementedException($"Filtering by {options.FilterFilePath} is not yet implemented");
+        }
+    }
+}

--- a/src/DotnetAffected.Core/ProjectDiscovery/ProjectDiscoveryManager.cs
+++ b/src/DotnetAffected.Core/ProjectDiscovery/ProjectDiscoveryManager.cs
@@ -14,10 +14,15 @@ namespace DotnetAffected.Core
                 return new DirectoryProjectDiscoverer().DiscoverProjects(options);
             }
 
-            // When a filtering file is provided, use an specific discoverer based on its path.
+            // When a filtering file is provided, use a specific discoverer based on its path.
             if (options.FilterFilePath.EndsWith(".sln"))
             {
                 return new SolutionFileProjectDiscoverer().DiscoverProjects(options);
+            }
+            
+            if (options.FilterFilePath.EndsWith(".proj"))
+            {
+                return new MSBuildProjectDiscoverer().DiscoverProjects(options);
             }
 
             throw new NotImplementedException($"Filtering by {options.FilterFilePath} is not yet implemented");

--- a/src/DotnetAffected.Core/ProjectDiscovery/SolutionFileProjectDiscoverer.cs
+++ b/src/DotnetAffected.Core/ProjectDiscovery/SolutionFileProjectDiscoverer.cs
@@ -9,7 +9,7 @@ namespace DotnetAffected.Core
     {
         public IEnumerable<string> DiscoverProjects(IDiscoveryOptions options)
         {
-            var solution = SolutionFile.Parse(options.SolutionPath);
+            var solution = SolutionFile.Parse(options.FilterFilePath);
 
             return solution.ProjectsInOrder
                 .Where(x => x.ProjectType != SolutionProjectType.SolutionFolder)

--- a/src/DotnetAffected.Core/ProjectGraphFactory.cs
+++ b/src/DotnetAffected.Core/ProjectGraphFactory.cs
@@ -26,7 +26,7 @@ namespace DotnetAffected.Core
         public ProjectGraph BuildProjectGraph()
         {
             // Discover all projects and build the graph
-            var allProjects = BuildProjectDiscoverer()
+            var allProjects = new ProjectDiscoveryManager()
                 .DiscoverProjects(_options);
 
             WriteLine($"Building Dependency Graph");
@@ -38,18 +38,6 @@ namespace DotnetAffected.Core
                 $"in {output.ConstructionMetrics.ConstructionTime:s\\.ff}s");
 
             return output;
-        }
-
-        private IProjectDiscoverer BuildProjectDiscoverer()
-        {
-            if (string.IsNullOrWhiteSpace(_options.SolutionPath))
-            {
-                WriteLine($"Discovering projects from {_options.RepositoryPath}");
-                return new DirectoryProjectDiscoverer();
-            }
-
-            WriteLine($"Discovering projects from Solution {_options.SolutionPath}");
-            return new SolutionFileProjectDiscoverer();
         }
 
         private void WriteLine(string? message = null)

--- a/src/dotnet-affected/Commands/AffectedGlobalOptions.cs
+++ b/src/dotnet-affected/Commands/AffectedGlobalOptions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.CommandLine;
 using System.Linq;
 
@@ -14,12 +15,21 @@ namespace Affected.Cli.Commands
             description: "Path to the root of the repository, where the .git directory is.\n" +
                          "[Defaults to current directory, or solution's directory when using --solution-path]");
 
+        [Obsolete]
         public static readonly Option<string> SolutionPathOption = new(
             aliases: new[]
             {
                 "--solution-path"
             },
-            description: "Path to a Solution file (.sln) used to discover projects that may be affected.\n" +
+            description: "[OBSOLETE: use --filter-file-path] Path to a Solution file (.sln) used to discover projects that may be affected.\n" +
+                         "When omitted, will search for project files inside --repository-path.");
+        
+        public static readonly Option<string> FilterFilePathOption = new(
+            aliases: new[]
+            {
+                "--filter-file-path"
+            },
+            description: "Path to a filter file (.sln) used to discover projects that may be affected.\n" +
                          "When omitted, will search for project files inside --repository-path.");
 
         public static readonly Option<bool> VerboseOption = new(aliases: new[]

--- a/src/dotnet-affected/Commands/AffectedGlobalOptions.cs
+++ b/src/dotnet-affected/Commands/AffectedGlobalOptions.cs
@@ -15,7 +15,6 @@ namespace Affected.Cli.Commands
             description: "Path to the root of the repository, where the .git directory is.\n" +
                          "[Defaults to current directory, or solution's directory when using --solution-path]");
 
-        [Obsolete]
         public static readonly Option<string> SolutionPathOption = new(
             aliases: new[]
             {

--- a/src/dotnet-affected/Commands/AffectedRootCommand.cs
+++ b/src/dotnet-affected/Commands/AffectedRootCommand.cs
@@ -22,6 +22,7 @@ namespace Affected.Cli.Commands
 
             this.AddGlobalOption(AffectedGlobalOptions.RepositoryPathOptions);
             this.AddGlobalOption(AffectedGlobalOptions.SolutionPathOption);
+            this.AddGlobalOption(AffectedGlobalOptions.FilterFilePathOption);
             this.AddGlobalOption(AffectedGlobalOptions.VerboseOption);
             this.AddGlobalOption(AffectedGlobalOptions.AssumeChangesOption);
             this.AddGlobalOption(AffectedGlobalOptions.FromOption);

--- a/src/dotnet-affected/Commands/Binding/AffectedOptionsBinder.cs
+++ b/src/dotnet-affected/Commands/Binding/AffectedOptionsBinder.cs
@@ -11,9 +11,19 @@ namespace Affected.Cli.Commands
         protected override AffectedOptions GetBoundValue(BindingContext bindingContext)
         {
             var parseResult = bindingContext.ParseResult;
+
+            // solutionFilePath is deprecated,
+            var filterFilePath = parseResult.GetValueForOption(AffectedGlobalOptions.FilterFilePathOption);
+            var solutionFilePath = parseResult.GetValueForOption(AffectedGlobalOptions.SolutionPathOption);
+
+            if (string.IsNullOrEmpty(filterFilePath))
+            {
+                filterFilePath = solutionFilePath;
+            }
+            
             return new AffectedOptions(
                 parseResult.GetValueForOption(AffectedGlobalOptions.RepositoryPathOptions),
-                parseResult.GetValueForOption(AffectedGlobalOptions.SolutionPathOption),
+                filterFilePath,
                 parseResult.GetValueForOption(AffectedGlobalOptions.FromOption),
                 parseResult.GetValueForOption(AffectedGlobalOptions.ToOption),
                 parseResult.GetValueForOption(AffectedGlobalOptions.ExclusionRegexOption)

--- a/test/DotnetAffected.Core.Tests/ChangeDetectionUsingTraversalProjectTests.cs
+++ b/test/DotnetAffected.Core.Tests/ChangeDetectionUsingTraversalProjectTests.cs
@@ -71,7 +71,7 @@ namespace DotnetAffected.Core.Tests
             // Create a traversal project which includes the project
             await this.Repository.CreateTraversalProjectAsync(traversalProjectPath, p =>
             {
-                p.AddItem("ProjectReference", "../../**/**/InventoryManagement.csproj");
+                p.AddItem("ProjectReference", "../**/**/InventoryManagement.csproj");
             });
 
             Assert.Single(AffectedSummary.ProjectsWithChangedFiles);

--- a/test/DotnetAffected.Core.Tests/ChangeDetectionUsingTraversalProjectTests.cs
+++ b/test/DotnetAffected.Core.Tests/ChangeDetectionUsingTraversalProjectTests.cs
@@ -1,0 +1,127 @@
+﻿using DotnetAffected.Testing.Utils;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DotnetAffected.Core.Tests
+{
+    /// <summary>
+    /// Tests for detecting changed projects when using a Traversal SDK project to filter.
+    /// This should cover all tests where filtering should be applied
+    /// </summary>
+    public class ChangeDetectionUsingTraversalProjectTests
+        : BaseDotnetAffectedTest
+    {
+        private string traversalProjectPath = "traversal-test.proj";
+
+        protected override AffectedOptions Options => new AffectedOptions(
+            this.Repository.Path,
+            Path.Combine(this.Repository.Path, this.traversalProjectPath));
+
+        [Fact]
+        public async Task When_project_inside_filtering_file_has_changes_project_should_have_changed()
+        {
+            // Create a project
+            var projectName = "InventoryManagement";
+            var msBuildProject = this.Repository.CreateCsProject(projectName);
+
+            // Create a traversal project which includes the project
+            await this.Repository.CreateTraversalProjectAsync(traversalProjectPath, msBuildProject.FullPath);
+
+            Assert.Single(AffectedSummary.ProjectsWithChangedFiles);
+            Assert.Empty(AffectedSummary.AffectedProjects);
+
+            var projectInfo = AffectedSummary.ProjectsWithChangedFiles.Single();
+            Assert.Equal(projectName, projectInfo.GetProjectName());
+            Assert.Equal(msBuildProject.FullPath, projectInfo.GetFullPath());
+        }
+        
+        [Fact]
+        public async Task When_project_inside_filtering_file_with_expressions_has_changes_project_should_have_changed()
+        {
+            // Create a project
+            var projectName = "InventoryManagement";
+            var msBuildProject = this.Repository.CreateCsProject(projectName);
+
+            // Create a traversal project which includes the project
+            await this.Repository.CreateTraversalProjectAsync(traversalProjectPath, p =>
+            {
+                p.AddItem("ProjectReference", "**/**/InventoryManagement.csproj");
+            });
+
+            Assert.Single(AffectedSummary.ProjectsWithChangedFiles);
+            Assert.Empty(AffectedSummary.AffectedProjects);
+
+            var projectInfo = AffectedSummary.ProjectsWithChangedFiles.Single();
+            Assert.Equal(projectName, projectInfo.GetProjectName());
+            Assert.Equal(msBuildProject.FullPath, projectInfo.GetFullPath());
+        }
+        
+        [Fact]
+        public async Task When_project_inside_filtering_file_with_expressions_upper_path_has_changes_project_should_have_changed()
+        {
+            // Create a project
+            var projectName = "InventoryManagement";
+            var msBuildProject = this.Repository.CreateCsProject(projectName);
+
+            var tvPath = Path.Join(this.Repository.Path, "/traversals");
+            Directory.CreateDirectory(tvPath);
+            traversalProjectPath = Path.Join(tvPath, "traversal-test.proj");
+            // Create a traversal project which includes the project
+            await this.Repository.CreateTraversalProjectAsync(traversalProjectPath, p =>
+            {
+                p.AddItem("ProjectReference", "../../**/**/InventoryManagement.csproj");
+            });
+
+            Assert.Single(AffectedSummary.ProjectsWithChangedFiles);
+            Assert.Empty(AffectedSummary.AffectedProjects);
+
+            var projectInfo = AffectedSummary.ProjectsWithChangedFiles.Single();
+            Assert.Equal(projectName, projectInfo.GetProjectName());
+            Assert.Equal(msBuildProject.FullPath, projectInfo.GetFullPath());
+        }
+
+        [Fact]
+        public async Task When_project_inside_filtering_file_should_ignore_changes_outside_filtering_file()
+        {
+            // Create a project
+            var projectName = "InventoryManagement";
+            var msBuildProject = this.Repository.CreateCsProject(projectName);
+
+            // Create a traversal project which includes the project
+            await this.Repository.CreateTraversalProjectAsync(traversalProjectPath, msBuildProject.FullPath);
+
+            // Create a project that is outside the solution
+            var outsiderproject = "OutsiderProject";
+            this.Repository.CreateCsProject(outsiderproject);
+
+            Assert.Single(AffectedSummary.ProjectsWithChangedFiles);
+            Assert.Empty(AffectedSummary.AffectedProjects);
+
+            var projectInfo = AffectedSummary.ProjectsWithChangedFiles.Single();
+            Assert.Equal(projectName, projectInfo.GetProjectName());
+            Assert.Equal(msBuildProject.FullPath, projectInfo.GetFullPath());
+        }
+
+        [Fact]
+        public async Task When_project_outside_filtering_file_has_changed_nothing_should_be_affected()
+        {
+            // Create a project
+            var projectName = "InventoryManagement";
+            var msBuildProject = this.Repository.CreateCsProject(projectName);
+
+            // Create a traversal project which includes the project
+            await this.Repository.CreateTraversalProjectAsync(traversalProjectPath, msBuildProject.FullPath);
+
+            // Commit so there are no changes
+            this.Repository.StageAndCommit();
+
+            // Create a project that is outside the solution
+            var outsiderName = "OutsiderProject";
+            this.Repository.CreateCsProject(outsiderName);
+
+            Assert.Empty(AffectedSummary.AffectedProjects);
+        }
+    }
+}


### PR DESCRIPTION
This PR deprecates the `--solution-file-path` argument being replaced by the new `--filter-file-path`. 

The `--solution-file-path` has not yet being removed, but is being discontinued. Using `--solution-file-path` is equivalent to using `--filter-file-path`

The `--filter-file-path` allows us to support multiple file types based off the **extension** of the file.
For example:

```shell
dotnet affected --solution-file-path ./my-solution.sln
# should be replaced by
dotnet affected --filter-file-path ./my-solution.sln

# new supported type: traversal project sdk:
dotnet affected --filter-file-path ./my-traversal-project.proj
```

In the future we could implement other file formats, like `json` or `yaml`

Fixes #87