### PR TITLE
chore: updates packages. drop net7.0 support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
 
         <LangVersion>9.0</LangVersion>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,14 +1,12 @@
-﻿<Project>
+<Project>
     <ItemGroup>
         <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
         <PackageVersion Include="System.CommandLine.Rendering" Version="0.4.0-alpha.22272.1" />
-        <PackageVersion Include="LibGit2Sharp" Version="0.27.0-preview-0182" />
-        <PackageVersion Include="MinVer" Version="4.3.0" />
+        <PackageVersion Include="LibGit2Sharp" Version="0.30.0" />
+        <PackageVersion Include="MinVer" Version="6.0.0" />
 
-        <PackageVersion Include="Microsoft.Build.Prediction" Version="1.2.1" />
-
-        <!-- REMARKS: Microsoft.Build.Locator v1.5.5 breaks runtime on Alpine Linux, see #75 -->
-        <PackageVersion Include="Microsoft.Build.Locator" Version="1.4.1" />
+        <PackageVersion Include="Microsoft.Build.Prediction" Version="1.2.18" />
+        <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
 
         <PackageVersion Include="BenchmarkDotNet" Version="0.13.5" />
         <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" Condition="'$(OS)' == 'Windows_NT'"/>
@@ -24,18 +22,10 @@
         <PackageVersion Include="System.CodeDom" Version="6.0.0" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-        <PackageVersion Include="Microsoft.Build" Version="17.5.0" />
-        <PackageVersion Include="Microsoft.Build.Framework" Version="17.5.0" />
-        <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.5.0" />
-        <PackageVersion Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
-        <PackageVersion Include="System.CodeDom" Version="7.0.0" />
-    </ItemGroup>
-
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageVersion Include="Microsoft.Build" Version="17.5.0" />
-        <PackageVersion Include="Microsoft.Build.Framework" Version="17.5.0" />
-        <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.5.0" />
+        <PackageVersion Include="Microsoft.Build" Version="17.11.4" />
+        <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" />
+        <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
         <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
         <PackageVersion Include="System.CodeDom" Version="8.0.0" />
     </ItemGroup>

--- a/eng/install-sdk.ps1
+++ b/eng/install-sdk.ps1
@@ -10,5 +10,4 @@ $globalJsonFile = "$PSScriptRoot\..\global.json"
 $dotnetInstallDir = "$PSScriptRoot\.dotnet"
 
 . $installScript  -InstallDir $dotnetInstallDir -JSonFile $globalJsonFile
-. $installScript  -InstallDir $dotnetInstallDir -Channel 7.0
 . $installScript  -InstallDir $dotnetInstallDir -Channel 6.0

--- a/eng/install-sdk.sh
+++ b/eng/install-sdk.sh
@@ -14,5 +14,4 @@ global_json_file="$(dirname "$0")/../global.json"
 dotnet_install_dir="$(dirname "$0")/.dotnet"
 
 "$install_script" --install-dir "$dotnet_install_dir" --jsonfile "$global_json_file"
-"$install_script" --install-dir "$dotnet_install_dir" --channel 7.0
 "$install_script" --install-dir "$dotnet_install_dir" --channel 6.0

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -1,13 +1,13 @@
-﻿<Project>
+<Project>
     <Import Project="../Directory.Packages.props" />
     <ItemGroup>
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
-        <PackageVersion Include="Moq" Version="4.18.4" />
-        <PackageVersion Include="xunit" Version="2.4.2" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
+        <PackageVersion Include="Moq" Version="4.20.72" />
+        <PackageVersion Include="xunit" Version="2.9.2" />
         <PackageVersion Include="xunit.core" Version="2.4.1" />
         <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
-        <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageVersion Include="coverlet.collector" Version="3.2.0"/>
-        <PackageVersion Include="XunitXml.TestLogger" Version="3.0.78" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0-pre.35"/>
+        <PackageVersion Include="coverlet.collector" Version="6.0.2"/>
+        <PackageVersion Include="XunitXml.TestLogger" Version="4.0.254" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
.NET 7 support ended May 14, 2024

Updates packages to latest possible versions.