### PR TITLE
fix : Various casing on "Version" should not throw

### DIFF
--- a/src/DotnetAffected.Core/NugetHelper.cs
+++ b/src/DotnetAffected.Core/NugetHelper.cs
@@ -1,6 +1,7 @@
 ﻿using DotnetAffected.Abstractions;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -43,7 +44,7 @@ namespace DotnetAffected.Core
                     }.Concat(conditions);
                 }
 
-                var version = versionOverride ?? item.Metadata.Single(m => m.Name == "Version")
+                var version = versionOverride ?? item.Metadata.Single(m => m.Name.Equals("Version", StringComparison.InvariantCultureIgnoreCase))
                     .EvaluatedValue;
 
                 return new PackageRef(

--- a/test/DotnetAffected.Core.Tests/NugetHelperTests.cs
+++ b/test/DotnetAffected.Core.Tests/NugetHelperTests.cs
@@ -1,0 +1,57 @@
+﻿using DotnetAffected.Testing.Utils;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DotnetAffected.Core.Tests
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class NugetHelperTests : BaseDotnetAffectedTest
+    {
+        [Fact]
+        public async Task When_Version_Attribute_Casing_Is_Not_Standard_Using_Central_Management_Package_Should_Not_Throw()
+        {
+            // Create a Directory.Packages.props file with non standard casing for "Version" attribute
+            var propsFile = @"
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include=""Some.Library"" version=""5.0.0"" />
+  </ItemGroup>
+</Project>
+";
+            var propsPath = Path.Combine(Repository.Path, "Directory.Packages.props");
+            await Repository.CreateTextFileAsync(propsPath, propsFile);
+
+            // Create a project with a nuget dependency
+            const string projectName = "InventoryManagement";
+            Repository.CreateCsProject(
+                projectName,
+                b => b.AddNuGetDependency("Some.Library"));
+            
+            // Commit all so there are no changes
+            Repository.StageAndCommit();
+
+            // update Directory.Packages.props file
+            propsFile = @"
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include=""Some.Library"" version=""6.0.0"" />
+  </ItemGroup>
+</Project>
+";
+            await Repository.CreateTextFileAsync(propsPath, propsFile);
+
+            // Verify that affected does not throw
+            var exception  = Record.Exception(() => AffectedSummary);
+            Assert.Null(exception);
+        }
+    }
+}


### PR DESCRIPTION
When trying to run dotnet affected on a large solution, I ran into an exception:

```
Unhandled exception: System.InvalidOperationException: Sequence contains no matching element
   at System.Linq.ThrowHelper.ThrowNoMatchException()
   at System.Linq.Enumerable.Single[TSource](IEnumerable`1 source, Func`2 predicate)
   at DotnetAffected.Core.NugetHelper.PackageRef.Create(ProjectItem item, String versionOverride) in /_/src/DotnetAffected.Core/NugetHelper.cs:line 46
   at DotnetAffected.Core.NugetHelper.ParseDirectoryPackageProps(Project project) in /_/src/DotnetAffected.Core/NugetHelper.cs:line 85
   at DotnetAffected.Core.Processor.AffectedProcessor.FindChangedNugetPackages(AffectedProcessorContext context) in /_/src/DotnetAffected.Core/Processor/AffectedProcessor.cs:line 120
   at DotnetAffected.Core.Processor.AffectedProcessor.DiscoverPackageChanges(AffectedProcessorContext context) in /_/src/DotnetAffected.Core/Processor/AffectedProcessor.cs:line 30
   at DotnetAffected.Core.Processor.AffectedProcessorBase.Process(AffectedProcessorContext context) in /_/src/DotnetAffected.Core/Processor/AffectedProcessorBase.cs:line 33
   at DotnetAffected.Core.AffectedExecutor.Execute() in /_/src/DotnetAffected.Core/AffectedExecutor.cs:line 41
   at Affected.Cli.Commands.InvocationContextExtensions.ExecuteAffectedExecutor(InvocationContext ctx) in /_/src/dotnet-affected/Commands/Binding/InvocationContextExtensions.cs:line 38
   at Affected.Cli.Commands.AffectedRootCommand.<>c.<<-ctor>b__4_0>d.MoveNext() in /_/src/dotnet-affected/Commands/AffectedRootCommand.cs:line 38

```

When debugging, it appeared that this was caused by a "Version" attribute in my Directory.Packages.props with this casing : "version".

Since Visual Studio does not seem to be case sensitive, i propose to merge this pull request to fix this issue.