### PR TITLE
feat: --filter-file-path to support relative paths

### DIFF
--- a/src/DotnetAffected.Core/AffectedOptions.cs
+++ b/src/DotnetAffected.Core/AffectedOptions.cs
@@ -25,7 +25,15 @@ namespace DotnetAffected.Core
             string? exclusionRegex = null)
         {
             RepositoryPath = DetermineRepositoryPath(repositoryPath, filterFilePath);
-            FilterFilePath = filterFilePath;
+
+            // Ensure the provided filter is a rooted path
+            if (!string.IsNullOrEmpty(filterFilePath))
+            {
+                FilterFilePath = Path.IsPathRooted(filterFilePath)
+                    ? filterFilePath
+                    : Path.Join(Environment.CurrentDirectory, filterFilePath);
+            }
+
             FromRef = fromRef ?? string.Empty;
             ToRef = toRef ?? string.Empty;
             ExclusionRegex = exclusionRegex;
@@ -76,8 +84,8 @@ namespace DotnetAffected.Core
             var filterFileDirectory = Path.GetDirectoryName(filterfilePath);
             if (string.IsNullOrWhiteSpace(filterFileDirectory))
             {
-                throw new InvalidOperationException(
-                    $"Failed to determine directory from filter file path path. Ensure the path exists: {filterfilePath}");
+                // A relative path to a file may be provided, in such case getting the directory name fails.
+                return Environment.CurrentDirectory;
             }
 
             return filterFileDirectory;

--- a/test/dotnet-affected.Tests/PathGenerationTests.cs
+++ b/test/dotnet-affected.Tests/PathGenerationTests.cs
@@ -14,23 +14,24 @@ namespace Affected.Cli.Tests
         {
             public IEnumerator<object[]> GetEnumerator()
             {
-                yield return new object[]
-                {
-                    "/home/lchaia/dotnet-affected", "", "/home/lchaia/dotnet-affected"
-                };
+                yield return new object[] { "/home/lchaia/dotnet-affected", "", "/home/lchaia/dotnet-affected", null };
                 yield return new object[]
                 {
                     "", "/home/lchaia/dotnet-affected/Affected.sln",
-                    Path.GetDirectoryName("/home/lchaia/dotnet-affected/Affected.sln")
+                    Path.GetDirectoryName("/home/lchaia/dotnet-affected/Affected.sln"),
+                    "/home/lchaia/dotnet-affected/Affected.sln"
                 };
                 yield return new object[]
                 {
                     "/home/lchaia/dotnet-affected", "/home/lchaia/dotnet-affected/subdirectory/other/Affected.sln",
-                    "/home/lchaia/dotnet-affected"
+                    "/home/lchaia/dotnet-affected", "/home/lchaia/dotnet-affected/subdirectory/other/Affected.sln",
                 };
+                yield return new object[] { "", "", Environment.CurrentDirectory, null };
+
                 yield return new object[]
                 {
-                    "", "", Environment.CurrentDirectory
+                    "", "Affected.sln", Environment.CurrentDirectory,
+                    Path.Join(Environment.CurrentDirectory, "Affected.sln")
                 };
             }
 
@@ -41,21 +42,20 @@ namespace Affected.Cli.Tests
         [ClassData(typeof(RepositoryPathsClassData))]
         public void Should_determine_repository_path_correctly(
             string repositoryPath,
-            string solutionPath,
-            string expected)
+            string filterFilePath,
+            string expectedRepository,
+            string expectedFilterFilePath)
         {
-            var options = new AffectedOptions(repositoryPath, solutionPath);
-            Assert.Equal(expected, options.RepositoryPath);
+            var options = new AffectedOptions(repositoryPath, filterFilePath);
+            Assert.Equal(expectedRepository, options.RepositoryPath);
+            Assert.Equal(expectedFilterFilePath, options.FilterFilePath);
         }
 
         private class OutputDirPathsClassData : IEnumerable<object[]>
         {
             public IEnumerator<object[]> GetEnumerator()
             {
-                yield return new object[]
-                {
-                    "/home/lchaia/dotnet-affected", "", "/home/lchaia/dotnet-affected"
-                };
+                yield return new object[] { "/home/lchaia/dotnet-affected", "", "/home/lchaia/dotnet-affected" };
                 yield return new object[]
                 {
                     "/home/lchaia/dotnet-affected", "relative/path",

--- a/test/dotnet-affected.Tests/PathGenerationTests.cs
+++ b/test/dotnet-affected.Tests/PathGenerationTests.cs
@@ -33,6 +33,12 @@ namespace Affected.Cli.Tests
                     "", "Affected.sln", Environment.CurrentDirectory,
                     Path.Join(Environment.CurrentDirectory, "Affected.sln")
                 };
+                
+                yield return new object[]
+                {
+                    "/home/lchaia/dotnet-affected", "Affected.sln", "/home/lchaia/dotnet-affected",
+                    Path.Join(Environment.CurrentDirectory, "Affected.sln")
+                };
             }
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();


### PR DESCRIPTION
Adds support for `--filter-file-path` to support relative paths.

When `--filter-file-path` is relative, it is always relative to the current working directory, even if a `--repository-path` is provided 

This table covers al supported cases:

| Repository Path                 | Filter File Path                                         | Expected Repository Path                 | Expected Filter File Path                                |
|---------------------------------|----------------------------------------------------------|------------------------------------------|----------------------------------------------------------|
| `/home/lchaia/dotnet-affected`  | `""`                                                     | `/home/lchaia/dotnet-affected`          | `null`                                                   |
| `""`                            | `/home/lchaia/dotnet-affected/Affected.sln`              | `/home/lchaia/dotnet-affected`          | `/home/lchaia/dotnet-affected/Affected.sln`              |
| `/home/lchaia/dotnet-affected`  | `/home/lchaia/dotnet-affected/subdirectory/other/Affected.sln` | `/home/lchaia/dotnet-affected` | `/home/lchaia/dotnet-affected/subdirectory/other/Affected.sln` |
| `""`                            | `""`                                                     | `Environment.CurrentDirectory`          | `null`                                                   |
| `""`                            | `Affected.sln`                                           | `Environment.CurrentDirectory`          | `Path.Join(Environment.CurrentDirectory, "Affected.sln")` |
| `/home/lchaia/dotnet-affected`  | `Affected.sln`                                          | `/home/lchaia/dotnet-affected`          | `Path.Join(Environment.CurrentDirectory, "Affected.sln")` |


Fixes #105 