### PR TITLE
chore: upgrade to dotnet 9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,85 +1,85 @@
 name: Build .NET
 on:
-    workflow_call:
-        inputs:
-            os_matrix:
-                description: "A JSON string array of OS matrix to build against"
-                default: '["macos-latest", "ubuntu-latest", "windows-latest"]'
-                required: false
-                type: string
+  workflow_call:
+    inputs:
+      os_matrix:
+        description: 'A JSON string array of OS matrix to build against'
+        default: "[\"macos-latest\", \"ubuntu-latest\", \"windows-latest\"]"
+        required: false
+        type: string
 
 jobs:
-    build:
-        runs-on: ${{ matrix.os }}
-        strategy:
-            fail-fast: false
-            matrix:
-                os: ${{fromJson(inputs.os_matrix)}}
-        env:
-            # https://www.donovanbrown.com/post/Stop-wasting-time-during-NET-Core-builds
-            DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
-            DOTNET_NOLOGO: "1"
-            DOTNET_CLI_TELEMETRY_OPTOUT: "1"
-            # See more here: https://docs.microsoft.com/en-us/dotnet/core/dependency-loading/default-probing#how-do-i-debug-the-probing-properties-construction.
-            COREHOST_TRACE: "0"
-            # See more here: https://docs.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-environment-variables.
-            NUGET_XMLDOC_MODE: "skip"
-            DOTNET_MULTILEVEL_LOOKUP: 0
-            CI_BUILD: "true"
-        steps:
-            - uses: actions/checkout@v2
-              with:
-                  fetch-depth: 0
-            - name: Install .NET
-              if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-              run: |
-                  ./eng/install-sdk.sh
-                  echo "DOTNET_ROOT=$GITHUB_WORKSPACE/eng/.dotnet" >> $GITHUB_ENV
-                  echo "$GITHUB_WORKSPACE/eng/.dotnet" >> $GITHUB_PATH
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{fromJson(inputs.os_matrix)}}
+    env:
+      # https://www.donovanbrown.com/post/Stop-wasting-time-during-NET-Core-builds
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: '1'
+      DOTNET_NOLOGO: '1'
+      DOTNET_CLI_TELEMETRY_OPTOUT: '1'
+      # See more here: https://docs.microsoft.com/en-us/dotnet/core/dependency-loading/default-probing#how-do-i-debug-the-probing-properties-construction.
+      COREHOST_TRACE: '0'
+      # See more here: https://docs.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-environment-variables.
+      NUGET_XMLDOC_MODE: 'skip'
+      DOTNET_MULTILEVEL_LOOKUP: 0
+      CI_BUILD: 'true'
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Install .NET
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+      run: |
+        ./eng/install-sdk.sh
+        echo "DOTNET_ROOT=$GITHUB_WORKSPACE/eng/.dotnet" >> $GITHUB_ENV
+        echo "$GITHUB_WORKSPACE/eng/.dotnet" >> $GITHUB_PATH
 
-            - name: Install .NET
-              if: matrix.os == 'windows-latest'
-              run: |
-                  ./eng/install-sdk.ps1
-                  echo "DOTNET_ROOT=$Env:GITHUB_WORKSPACE/eng/.dotnet" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-                  echo "$Env:GITHUB_WORKSPACE/eng/.dotnet" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf-8 -Append
+    - name: Install .NET
+      if: matrix.os == 'windows-latest'
+      run: |
+        ./eng/install-sdk.ps1
+        echo "DOTNET_ROOT=$Env:GITHUB_WORKSPACE/eng/.dotnet" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+        echo "$Env:GITHUB_WORKSPACE/eng/.dotnet" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf-8 -Append
 
-            - name: Print host info
-              run: printenv && dotnet --info
+    - name: Print host info
+      run: printenv && dotnet --info
 
-            - name: Restore dependencies
-              run: dotnet restore
+    - name: Restore dependencies
+      run: dotnet restore
 
-            - name: Build
-              run: dotnet build --no-restore --no-incremental /WarnAsError
+    - name: Build
+      run: dotnet build --no-restore --no-incremental /WarnAsError
 
-            - name: Test
-              run: dotnet test --no-build
+    - name: Test
+      run: dotnet test --no-build
 
-            - name: Run Tool PowerShell
-              if: matrix.os == 'windows-latest'
-              shell: pwsh
-              run: ./src/dotnet-affected/bin/Debug/net9.0/dotnet-affected -p $Env:GITHUB_WORKSPACE --assume-changes dotnet-affected -v
+    - name: Run Tool PowerShell
+      if: matrix.os == 'windows-latest'
+      shell: pwsh
+      run: ./src/dotnet-affected/bin/Debug/net9.0/dotnet-affected -p $Env:GITHUB_WORKSPACE --assume-changes dotnet-affected -v
 
-            - name: Run Tool Bash
-              if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-              shell: bash
-              run: ./src/dotnet-affected/bin/Debug/net9.0/dotnet-affected -p $GITHUB_WORKSPACE --assume-changes dotnet-affected -v
+    - name: Run Tool Bash
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+      shell: bash
+      run: ./src/dotnet-affected/bin/Debug/net9.0/dotnet-affected -p $GITHUB_WORKSPACE --assume-changes dotnet-affected -v
 
-            - name: Pack
-              if: success() && matrix.os == 'ubuntu-latest'
-              run: dotnet pack --no-restore --no-build --configuration Debug --include-symbols -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/packages
+    - name: Pack
+      if: success() && matrix.os == 'ubuntu-latest'
+      run: dotnet pack --no-restore --no-build --configuration Debug --include-symbols -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/packages
 
-            - uses: actions/upload-artifact@v3
-              name: "Upload Packages"
-              if: success() && matrix.os == 'ubuntu-latest'
-              with:
-                  name: packages
-                  path: ${{ github.workspace }}/packages/**/*
+    - uses: actions/upload-artifact@v3
+      name: 'Upload Packages'
+      if: success() && matrix.os == 'ubuntu-latest'
+      with:
+        name: packages
+        path: ${{ github.workspace }}/packages/**/*
 
-            - uses: actions/upload-artifact@v3
-              name: "Upload Artifacts"
-              if: success() && matrix.os == 'ubuntu-latest'
-              with:
-                  name: artifacts
-                  path: src/dotnet-affected/bin/Debug/net9.0/
+    - uses: actions/upload-artifact@v3
+      name: 'Upload Artifacts'
+      if: success() && matrix.os == 'ubuntu-latest'
+      with:
+        name: artifacts
+        path: src/dotnet-affected/bin/Debug/net9.0/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,85 +1,85 @@
 name: Build .NET
 on:
-  workflow_call:
-    inputs:
-      os_matrix:
-        description: 'A JSON string array of OS matrix to build against'
-        default: "[\"macos-latest\", \"ubuntu-latest\", \"windows-latest\"]"
-        required: false
-        type: string
+    workflow_call:
+        inputs:
+            os_matrix:
+                description: "A JSON string array of OS matrix to build against"
+                default: '["macos-latest", "ubuntu-latest", "windows-latest"]'
+                required: false
+                type: string
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ${{fromJson(inputs.os_matrix)}}
-    env:
-      # https://www.donovanbrown.com/post/Stop-wasting-time-during-NET-Core-builds
-      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: '1'
-      DOTNET_NOLOGO: '1'
-      DOTNET_CLI_TELEMETRY_OPTOUT: '1'
-      # See more here: https://docs.microsoft.com/en-us/dotnet/core/dependency-loading/default-probing#how-do-i-debug-the-probing-properties-construction.
-      COREHOST_TRACE: '0'
-      # See more here: https://docs.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-environment-variables.
-      NUGET_XMLDOC_MODE: 'skip'
-      DOTNET_MULTILEVEL_LOOKUP: 0
-      CI_BUILD: 'true'
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Install .NET
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-      run: |
-        ./eng/install-sdk.sh
-        echo "DOTNET_ROOT=$GITHUB_WORKSPACE/eng/.dotnet" >> $GITHUB_ENV
-        echo "$GITHUB_WORKSPACE/eng/.dotnet" >> $GITHUB_PATH
+    build:
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+                os: ${{fromJson(inputs.os_matrix)}}
+        env:
+            # https://www.donovanbrown.com/post/Stop-wasting-time-during-NET-Core-builds
+            DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
+            DOTNET_NOLOGO: "1"
+            DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+            # See more here: https://docs.microsoft.com/en-us/dotnet/core/dependency-loading/default-probing#how-do-i-debug-the-probing-properties-construction.
+            COREHOST_TRACE: "0"
+            # See more here: https://docs.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-environment-variables.
+            NUGET_XMLDOC_MODE: "skip"
+            DOTNET_MULTILEVEL_LOOKUP: 0
+            CI_BUILD: "true"
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+            - name: Install .NET
+              if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+              run: |
+                  ./eng/install-sdk.sh
+                  echo "DOTNET_ROOT=$GITHUB_WORKSPACE/eng/.dotnet" >> $GITHUB_ENV
+                  echo "$GITHUB_WORKSPACE/eng/.dotnet" >> $GITHUB_PATH
 
-    - name: Install .NET
-      if: matrix.os == 'windows-latest'
-      run: |
-        ./eng/install-sdk.ps1
-        echo "DOTNET_ROOT=$Env:GITHUB_WORKSPACE/eng/.dotnet" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-        echo "$Env:GITHUB_WORKSPACE/eng/.dotnet" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf-8 -Append
+            - name: Install .NET
+              if: matrix.os == 'windows-latest'
+              run: |
+                  ./eng/install-sdk.ps1
+                  echo "DOTNET_ROOT=$Env:GITHUB_WORKSPACE/eng/.dotnet" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+                  echo "$Env:GITHUB_WORKSPACE/eng/.dotnet" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf-8 -Append
 
-    - name: Print host info
-      run: printenv && dotnet --info
+            - name: Print host info
+              run: printenv && dotnet --info
 
-    - name: Restore dependencies
-      run: dotnet restore
+            - name: Restore dependencies
+              run: dotnet restore
 
-    - name: Build
-      run: dotnet build --no-restore --no-incremental /WarnAsError
+            - name: Build
+              run: dotnet build --no-restore --no-incremental /WarnAsError
 
-    - name: Test
-      run: dotnet test --no-build
+            - name: Test
+              run: dotnet test --no-build
 
-    - name: Run Tool PowerShell
-      if: matrix.os == 'windows-latest'
-      shell: pwsh
-      run: ./src/dotnet-affected/bin/Debug/net6.0/dotnet-affected -p $Env:GITHUB_WORKSPACE --assume-changes dotnet-affected -v
+            - name: Run Tool PowerShell
+              if: matrix.os == 'windows-latest'
+              shell: pwsh
+              run: ./src/dotnet-affected/bin/Debug/net9.0/dotnet-affected -p $Env:GITHUB_WORKSPACE --assume-changes dotnet-affected -v
 
-    - name: Run Tool Bash
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-      shell: bash
-      run: ./src/dotnet-affected/bin/Debug/net6.0/dotnet-affected -p $GITHUB_WORKSPACE --assume-changes dotnet-affected -v
+            - name: Run Tool Bash
+              if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+              shell: bash
+              run: ./src/dotnet-affected/bin/Debug/net9.0/dotnet-affected -p $GITHUB_WORKSPACE --assume-changes dotnet-affected -v
 
-    - name: Pack
-      if: success() && matrix.os == 'ubuntu-latest'
-      run: dotnet pack --no-restore --no-build --configuration Debug --include-symbols -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/packages
+            - name: Pack
+              if: success() && matrix.os == 'ubuntu-latest'
+              run: dotnet pack --no-restore --no-build --configuration Debug --include-symbols -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/packages
 
-    - uses: actions/upload-artifact@v3
-      name: 'Upload Packages'
-      if: success() && matrix.os == 'ubuntu-latest'
-      with:
-        name: packages
-        path: ${{ github.workspace }}/packages/**/*
+            - uses: actions/upload-artifact@v3
+              name: "Upload Packages"
+              if: success() && matrix.os == 'ubuntu-latest'
+              with:
+                  name: packages
+                  path: ${{ github.workspace }}/packages/**/*
 
-    - uses: actions/upload-artifact@v3
-      name: 'Upload Artifacts'
-      if: success() && matrix.os == 'ubuntu-latest'
-      with:
-        name: artifacts
-        path: src/dotnet-affected/bin/Debug/net8.0/
+            - uses: actions/upload-artifact@v3
+              name: "Upload Artifacts"
+              if: success() && matrix.os == 'ubuntu-latest'
+              with:
+                  name: artifacts
+                  path: src/dotnet-affected/bin/Debug/net9.0/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 
         <LangVersion>9.0</LangVersion>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
 
         <LangVersion>9.0</LangVersion>
 
@@ -8,6 +8,9 @@
 
         <!-- https://github.com/NuGet/Home/wiki/Centrally-managing-NuGet-package-versions -->
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+
+        <NuGetAudit>true</NuGetAudit>
+        <NuGetAuditMode>direct</NuGetAuditMode>
     </PropertyGroup>
 
     <!-- Some general configuration applied to all projects -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
         <PackageVersion Include="Microsoft.Build.Prediction" Version="1.2.18" />
         <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
 
-        <PackageVersion Include="BenchmarkDotNet" Version="0.13.5" />
+        <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
         <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" Condition="'$(OS)' == 'Windows_NT'"/>
 
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" Condition="'$(ContinuousIntegrationBuild)' == 'true'"/>
@@ -28,6 +28,14 @@
         <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
         <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
         <PackageVersion Include="System.CodeDom" Version="8.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+        <PackageVersion Include="Microsoft.Build" Version="17.12.6" />
+        <PackageVersion Include="Microsoft.Build.Framework" Version="17.12.6" />
+        <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.12.6" />
+        <PackageVersion Include="System.Configuration.ConfigurationManager" Version="9.0.0" />
+        <PackageVersion Include="System.CodeDom" Version="9.0.0" />
     </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,18 +8,10 @@
         <PackageVersion Include="Microsoft.Build.Prediction" Version="1.2.18" />
         <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
 
+        <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
         <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" Condition="'$(OS)' == 'Windows_NT'"/>
 
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" Condition="'$(ContinuousIntegrationBuild)' == 'true'"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-        <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
-        <PackageVersion Include="Microsoft.Build.Framework" Version="17.3.2" />
-        <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.3.2" />
-        <PackageVersion Include="System.Configuration.ConfigurationManager" Version="6.0.2" />
-        <PackageVersion Include="System.CodeDom" Version="6.0.0" />
-        <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
@@ -28,16 +20,14 @@
         <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
         <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
         <PackageVersion Include="System.CodeDom" Version="8.0.0" />
-        <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageVersion Include="Microsoft.Build" Version="17.11.4" />
-        <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" />
-        <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
+        <PackageVersion Include="Microsoft.Build" Version="17.12.6" />
+        <PackageVersion Include="Microsoft.Build.Framework" Version="17.12.6" />
+        <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.12.6" />
         <PackageVersion Include="System.Configuration.ConfigurationManager" Version="9.0.0" />
         <PackageVersion Include="System.CodeDom" Version="9.0.0" />
-        <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,9 +32,9 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageVersion Include="Microsoft.Build" Version="17.12.6" />
-        <PackageVersion Include="Microsoft.Build.Framework" Version="17.12.6" />
-        <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.12.6" />
+        <PackageVersion Include="Microsoft.Build" Version="17.11.4" />
+        <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" />
+        <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
         <PackageVersion Include="System.Configuration.ConfigurationManager" Version="9.0.0" />
         <PackageVersion Include="System.CodeDom" Version="9.0.0" />
         <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,6 @@
         <PackageVersion Include="Microsoft.Build.Prediction" Version="1.2.18" />
         <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
 
-        <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
         <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" Condition="'$(OS)' == 'Windows_NT'"/>
 
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" Condition="'$(ContinuousIntegrationBuild)' == 'true'"/>
@@ -18,16 +17,18 @@
         <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
         <PackageVersion Include="Microsoft.Build.Framework" Version="17.3.2" />
         <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.3.2" />
-        <PackageVersion Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+        <PackageVersion Include="System.Configuration.ConfigurationManager" Version="6.0.2" />
         <PackageVersion Include="System.CodeDom" Version="6.0.0" />
+        <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
         <PackageVersion Include="Microsoft.Build" Version="17.11.4" />
         <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" />
         <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
-        <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+        <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
         <PackageVersion Include="System.CodeDom" Version="8.0.0" />
+        <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
@@ -36,6 +37,7 @@
         <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.12.6" />
         <PackageVersion Include="System.Configuration.ConfigurationManager" Version="9.0.0" />
         <PackageVersion Include="System.CodeDom" Version="9.0.0" />
+        <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     </ItemGroup>
 
 </Project>

--- a/eng/install-sdk.ps1
+++ b/eng/install-sdk.ps1
@@ -10,5 +10,4 @@ $globalJsonFile = "$PSScriptRoot\..\global.json"
 $dotnetInstallDir = "$PSScriptRoot\.dotnet"
 
 . $installScript  -InstallDir $dotnetInstallDir -JSonFile $globalJsonFile
-. $installScript  -InstallDir $dotnetInstallDir -Channel 6.0
 . $installScript  -InstallDir $dotnetInstallDir -Channel 8.0

--- a/eng/install-sdk.ps1
+++ b/eng/install-sdk.ps1
@@ -11,3 +11,4 @@ $dotnetInstallDir = "$PSScriptRoot\.dotnet"
 
 . $installScript  -InstallDir $dotnetInstallDir -JSonFile $globalJsonFile
 . $installScript  -InstallDir $dotnetInstallDir -Channel 6.0
+. $installScript  -InstallDir $dotnetInstallDir -Channel 8.0

--- a/eng/install-sdk.sh
+++ b/eng/install-sdk.sh
@@ -14,5 +14,4 @@ global_json_file="$(dirname "$0")/../global.json"
 dotnet_install_dir="$(dirname "$0")/.dotnet"
 
 "$install_script" --install-dir "$dotnet_install_dir" --jsonfile "$global_json_file"
-"$install_script" --install-dir "$dotnet_install_dir" --channel 6.0
 "$install_script" --install-dir "$dotnet_install_dir" --channel 8.0

--- a/eng/install-sdk.sh
+++ b/eng/install-sdk.sh
@@ -15,3 +15,4 @@ dotnet_install_dir="$(dirname "$0")/.dotnet"
 
 "$install_script" --install-dir "$dotnet_install_dir" --jsonfile "$global_json_file"
 "$install_script" --install-dir "$dotnet_install_dir" --channel 6.0
+"$install_script" --install-dir "$dotnet_install_dir" --channel 8.0

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
     "sdk": {
-        "version": "8.0.401",
+        "version": "9.0.100",
         "allowPrerelease": true
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
     "sdk": {
-        "version": "9.0.100",
+        "version": "9.0.101",
         "allowPrerelease": true
     },
     "msbuild-sdks": {

--- a/global.json
+++ b/global.json
@@ -2,5 +2,8 @@
     "sdk": {
         "version": "9.0.100",
         "allowPrerelease": true
+    },
+    "msbuild-sdks": {
+        "Microsoft.Build.Traversal": "4.1.0"
     }
 }

--- a/global.json
+++ b/global.json
@@ -2,8 +2,5 @@
     "sdk": {
         "version": "9.0.101",
         "allowPrerelease": true
-    },
-    "msbuild-sdks": {
-        "Microsoft.Build.Traversal": "4.1.0"
     }
 }

--- a/src/dotnet-affected/Infrastructure/Formatters/TraversalProjectOutputFormatter.cs
+++ b/src/dotnet-affected/Infrastructure/Formatters/TraversalProjectOutputFormatter.cs
@@ -19,8 +19,10 @@ namespace Affected.Cli.Formatters
             var stringReader = new StringReader(projectRootElement);
             var xmlReader = new XmlTextReader(stringReader);
             var root = ProjectRootElement.Create(xmlReader);
-
-            var project = new Project(root);
+            
+            // REMARKS: IgnoreMissingImports is required due to the Microsoft.Build.Traversal Sdk not being found
+            // on macos/darwin. We don't really need to evaluate the project, we just need to build the RawXml.
+            var project = new Project(root, null, null, ProjectCollection.GlobalProjectCollection, ProjectLoadSettings.IgnoreMissingImports);
 
             // Find all affected and add them as project references
             foreach (var projectInfo in projects)

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -1,13 +1,13 @@
 <Project>
     <Import Project="../Directory.Packages.props" />
     <ItemGroup>
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
         <PackageVersion Include="Moq" Version="4.20.72" />
         <PackageVersion Include="xunit" Version="2.9.2" />
-        <PackageVersion Include="xunit.core" Version="2.4.1" />
+        <PackageVersion Include="xunit.core" Version="2.9.2" />
         <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
-        <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0-pre.35"/>
+        <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0-pre.49"/>
         <PackageVersion Include="coverlet.collector" Version="6.0.2"/>
-        <PackageVersion Include="XunitXml.TestLogger" Version="4.0.254" />
+        <PackageVersion Include="XunitXml.TestLogger" Version="4.1.0" />
     </ItemGroup>
 </Project>

--- a/test/DotnetAffected.Testing.Utils/Repository/TemporaryRepositoryExtensions.cs
+++ b/test/DotnetAffected.Testing.Utils/Repository/TemporaryRepositoryExtensions.cs
@@ -51,7 +51,7 @@ namespace DotnetAffected.Testing.Utils
             // Directory.Build.Props / Directory.Packages.props
             project.Sdk = "Microsoft.NET.Sdk";
             // Required for net8.0 MSBuild Project Creation
-            project.AddProperty("TargetFrameworks", "net6.0,net8.0,net9.0");
+            project.AddProperty("TargetFrameworks", "net8.0;net9.0");
             customizer?.Invoke(project);
 
             project.Save();

--- a/test/DotnetAffected.Testing.Utils/Repository/TemporaryRepositoryExtensions.cs
+++ b/test/DotnetAffected.Testing.Utils/Repository/TemporaryRepositoryExtensions.cs
@@ -51,7 +51,7 @@ namespace DotnetAffected.Testing.Utils
             // Directory.Build.Props / Directory.Packages.props
             project.Sdk = "Microsoft.NET.Sdk";
             // Required for net8.0 MSBuild Project Creation
-            project.AddProperty("TargetFrameworks", "net6.0,net8.0");
+            project.AddProperty("TargetFrameworks", "net6.0,net8.0,net9.0");
             customizer?.Invoke(project);
 
             project.Save();


### PR DESCRIPTION
- `global.json` was updated to `9.0.100`
- `net9.0` target framework was added
- Latest packages are now used when targeting `dotnet9`
- Test packages were updated to the latest version 
- `net6.0` target framework was removed since its end of support (November 12th, 2024)