### PR TITLE
Bumping the version of MSBuild Traversal to 4.1.82

### DIFF
--- a/src/dotnet-affected/Infrastructure/Formatters/TraversalProjectOutputFormatter.cs
+++ b/src/dotnet-affected/Infrastructure/Formatters/TraversalProjectOutputFormatter.cs
@@ -15,7 +15,7 @@ namespace Affected.Cli.Formatters
 
         public Task<string> Format(IEnumerable<IProjectInfo> projects)
         {
-            var projectRootElement = @"<Project Sdk=""Microsoft.Build.Traversal/4.1.0""></Project>";
+            var projectRootElement = @"<Project Sdk=""Microsoft.Build.Traversal/4.1.82""></Project>";
             var stringReader = new StringReader(projectRootElement);
             var xmlReader = new XmlTextReader(stringReader);
             var root = ProjectRootElement.Create(xmlReader);

--- a/test/DotnetAffected.Testing.Utils/Repository/TemporaryRepositoryExtensions.cs
+++ b/test/DotnetAffected.Testing.Utils/Repository/TemporaryRepositoryExtensions.cs
@@ -168,7 +168,7 @@ namespace DotnetAffected.Testing.Utils
             string traversalProjectPath,
             Action<Project> callback)
         {
-            var projectRootElement = @"<Project Sdk=""Microsoft.Build.Traversal/4.1.0""></Project>";
+            var projectRootElement = @"<Project Sdk=""Microsoft.Build.Traversal/4.1.82""></Project>";
             var stringReader = new StringReader(projectRootElement);
             var xmlReader = new XmlTextReader(stringReader);
             var root = ProjectRootElement.Create(xmlReader);

--- a/test/dotnet-affected.Tests/Formatters/TraversalFormatterTests.cs
+++ b/test/dotnet-affected.Tests/Formatters/TraversalFormatterTests.cs
@@ -21,7 +21,7 @@ namespace Affected.Cli.Tests.Formatters
             var output = await formatter.Format(projects);
 
             CustomAssertions.LineSequenceEquals(output,
-                l => Assert.Contains("Microsoft.Build.Traversal/4.1.0", l),
+                l => Assert.Contains("Microsoft.Build.Traversal/4.1.82", l),
                 l => Assert.Contains("ItemGroup", l),
                 l => Assert.Contains(projectPath, l),
                 l => Assert.Contains("ItemGroup", l),
@@ -44,7 +44,7 @@ namespace Affected.Cli.Tests.Formatters
             var output = await formatter.Format(projects);
 
             CustomAssertions.LineSequenceEquals(output,
-                l => Assert.Contains("Microsoft.Build.Traversal/4.1.0", l),
+                l => Assert.Contains("Microsoft.Build.Traversal/4.1.82", l),
                 l => Assert.Contains("ItemGroup", l),
                 l => Assert.Contains(secondProjectPath, l),
                 l => Assert.Contains(firstProjectPath, l),


### PR DESCRIPTION
The version of MSBuild Traversal (4.1.0) doesn't support the `PublishContainer` task, which was fixed in the latest version (4.1.82)

This change will bump the version of the Traversal library to the latest version to support this.

More details here: https://github.com/microsoft/MSBuildSdks/issues/565