### PR TITLE
chore: upgrade to dotnet 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,12 +59,12 @@ jobs:
     - name: Run Tool PowerShell
       if: matrix.os == 'windows-latest'
       shell: pwsh
-      run: ./src/dotnet-affected/bin/Debug/net9.0/dotnet-affected -p $Env:GITHUB_WORKSPACE --assume-changes dotnet-affected -v
+      run: ./src/dotnet-affected/bin/Debug/net10.0/dotnet-affected -p $Env:GITHUB_WORKSPACE --assume-changes dotnet-affected -v
 
     - name: Run Tool Bash
       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
       shell: bash
-      run: ./src/dotnet-affected/bin/Debug/net9.0/dotnet-affected -p $GITHUB_WORKSPACE --assume-changes dotnet-affected -v
+      run: ./src/dotnet-affected/bin/Debug/net10.0/dotnet-affected -p $GITHUB_WORKSPACE --assume-changes dotnet-affected -v
 
     - name: Pack
       if: success() && matrix.os == 'ubuntu-latest'
@@ -82,4 +82,4 @@ jobs:
       if: success() && matrix.os == 'ubuntu-latest'
       with:
         name: artifacts
-        path: src/dotnet-affected/bin/Debug/net9.0/
+        path: src/dotnet-affected/bin/Debug/net10.0/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 
         <LangVersion>9.0</LangVersion>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,19 +16,27 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageVersion Include="Microsoft.Build" Version="17.11.4" />
-        <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" />
-        <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
+        <PackageVersion Include="Microsoft.Build" Version="17.11.48" />
+        <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.48" />
+        <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.48" />
         <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
         <PackageVersion Include="System.CodeDom" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageVersion Include="Microsoft.Build" Version="17.12.6" />
-        <PackageVersion Include="Microsoft.Build.Framework" Version="17.12.6" />
-        <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.12.6" />
-        <PackageVersion Include="System.Configuration.ConfigurationManager" Version="9.0.0" />
-        <PackageVersion Include="System.CodeDom" Version="9.0.0" />
+        <PackageVersion Include="Microsoft.Build" Version="17.12.50" />
+        <PackageVersion Include="Microsoft.Build.Framework" Version="17.12.50" />
+        <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.12.50" />
+        <PackageVersion Include="System.Configuration.ConfigurationManager" Version="9.0.11" />
+        <PackageVersion Include="System.CodeDom" Version="9.0.11" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageVersion Include="Microsoft.Build" Version="18.0.2" />
+        <PackageVersion Include="Microsoft.Build.Framework" Version="18.0.2" />
+        <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.0.2" />
+        <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.0" />
+        <PackageVersion Include="System.CodeDom" Version="10.0.0" />
     </ItemGroup>
 
 </Project>

--- a/eng/install-sdk.ps1
+++ b/eng/install-sdk.ps1
@@ -10,4 +10,4 @@ $globalJsonFile = "$PSScriptRoot\..\global.json"
 $dotnetInstallDir = "$PSScriptRoot\.dotnet"
 
 . $installScript  -InstallDir $dotnetInstallDir -JSonFile $globalJsonFile
-. $installScript  -InstallDir $dotnetInstallDir -Channel 8.0
+. $installScript  -InstallDir $dotnetInstallDir -Channel 10.0

--- a/eng/install-sdk.ps1
+++ b/eng/install-sdk.ps1
@@ -13,5 +13,5 @@ $dotnetInstallDir = "$PSScriptRoot\.dotnet"
 . $installScript -InstallDir $dotnetInstallDir -JSonFile $globalJsonFile
 
 # Runtimes for tests
-. $installScript -InstallDir $dotnetInstallDir -Runtime dotnet -Channel 8.0
-. $installScript -InstallDir $dotnetInstallDir -Runtime dotnet -Channel 9.0
+. $installScript -InstallDir $dotnetInstallDir -Channel 8.0
+. $installScript -InstallDir $dotnetInstallDir -Channel 9.0

--- a/eng/install-sdk.ps1
+++ b/eng/install-sdk.ps1
@@ -9,5 +9,9 @@ Invoke-WebRequest -Uri $installScriptUrl -OutFile $installScript -MaximumRetryCo
 $globalJsonFile = "$PSScriptRoot\..\global.json"
 $dotnetInstallDir = "$PSScriptRoot\.dotnet"
 
-. $installScript  -InstallDir $dotnetInstallDir -JSonFile $globalJsonFile
-. $installScript  -InstallDir $dotnetInstallDir -Channel 10.0
+# SDK from global.json 
+. $installScript -InstallDir $dotnetInstallDir -JSonFile $globalJsonFile
+
+# Runtimes for tests
+. $installScript -InstallDir $dotnetInstallDir -Runtime dotnet -Channel 8.0
+. $installScript -InstallDir $dotnetInstallDir -Runtime dotnet -Channel 9.0

--- a/eng/install-sdk.sh
+++ b/eng/install-sdk.sh
@@ -14,4 +14,4 @@ global_json_file="$(dirname "$0")/../global.json"
 dotnet_install_dir="$(dirname "$0")/.dotnet"
 
 "$install_script" --install-dir "$dotnet_install_dir" --jsonfile "$global_json_file"
-"$install_script" --install-dir "$dotnet_install_dir" --channel 8.0
+"$install_script" --install-dir "$dotnet_install_dir" --channel 10.0

--- a/eng/install-sdk.sh
+++ b/eng/install-sdk.sh
@@ -13,5 +13,9 @@ chmod +x "$install_script"
 global_json_file="$(dirname "$0")/../global.json"
 dotnet_install_dir="$(dirname "$0")/.dotnet"
 
+# SDK from global.json
 "$install_script" --install-dir "$dotnet_install_dir" --jsonfile "$global_json_file"
-"$install_script" --install-dir "$dotnet_install_dir" --channel 10.0
+
+# Runtimes for tests
+"$install_script" --install-dir "$dotnet_install_dir" --runtime dotnet --channel 8.0
+"$install_script" --install-dir "$dotnet_install_dir" --runtime dotnet --channel 9.0

--- a/eng/install-sdk.sh
+++ b/eng/install-sdk.sh
@@ -17,5 +17,5 @@ dotnet_install_dir="$(dirname "$0")/.dotnet"
 "$install_script" --install-dir "$dotnet_install_dir" --jsonfile "$global_json_file"
 
 # Runtimes for tests
-"$install_script" --install-dir "$dotnet_install_dir" --runtime dotnet --channel 8.0
-"$install_script" --install-dir "$dotnet_install_dir" --runtime dotnet --channel 9.0
+"$install_script" --install-dir "$dotnet_install_dir" --channel 8.0
+"$install_script" --install-dir "$dotnet_install_dir" --channel 9.0

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
     "sdk": {
-        "version": "9.0.101",
+        "version": "10.0.100",
         "allowPrerelease": true
     }
 }

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -1,13 +1,13 @@
 <Project>
     <Import Project="../Directory.Packages.props" />
     <ItemGroup>
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
         <PackageVersion Include="Moq" Version="4.20.72" />
-        <PackageVersion Include="xunit" Version="2.9.2" />
-        <PackageVersion Include="xunit.core" Version="2.9.2" />
+        <PackageVersion Include="xunit" Version="2.9.3" />
+        <PackageVersion Include="xunit.core" Version="2.9.3" />
         <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
-        <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0-pre.49"/>
-        <PackageVersion Include="coverlet.collector" Version="6.0.2"/>
-        <PackageVersion Include="XunitXml.TestLogger" Version="4.1.0" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5"/>
+        <PackageVersion Include="coverlet.collector" Version="6.0.4"/>
+        <PackageVersion Include="XunitXml.TestLogger" Version="7.0.2" />
     </ItemGroup>
 </Project>

--- a/test/DotnetAffected.Tasks.Tests/Utils.cs
+++ b/test/DotnetAffected.Tasks.Tests/Utils.cs
@@ -14,24 +14,20 @@ namespace DotnetAffected.Tasks.Tests
 
         private static readonly Lazy<string> TargetFrameworkLocal = new (() =>
         {
-            var targetFramework = typeof(Utils).Assembly
+            var targetFrameworkAttribute = typeof(Utils).Assembly
                 .GetCustomAttributes(typeof(System.Runtime.Versioning.TargetFrameworkAttribute), false)
                 .OfType<System.Runtime.Versioning.TargetFrameworkAttribute>()
-                .Single()
-                .FrameworkName;
-
-            var majorVersion = new Regex(".+,Version=v(\\d).(\\d)")
-                .Match(targetFramework)
-                .Groups.Values.Skip(1)
-                .Select(g => int.Parse(g.Value))
-                .First();
+                .Single();
+            
+            var frameworkName = new System.Runtime.Versioning.FrameworkName(targetFrameworkAttribute.FrameworkName);
+            var majorVersion = frameworkName.Version.Major;
 
             switch (majorVersion)
             {
                 case >= 5:
                     return $"net{majorVersion}.0";
                 default:
-                    throw new NotSupportedException($"Invalid TargetFramework: {targetFramework}");
+                    throw new NotSupportedException($"Invalid TargetFramework: {frameworkName}");
             }
         });
     }

--- a/test/DotnetAffected.Testing.Utils/Repository/TemporaryRepositoryExtensions.cs
+++ b/test/DotnetAffected.Testing.Utils/Repository/TemporaryRepositoryExtensions.cs
@@ -51,7 +51,7 @@ namespace DotnetAffected.Testing.Utils
             // Directory.Build.Props / Directory.Packages.props
             project.Sdk = "Microsoft.NET.Sdk";
             // Required for net8.0 MSBuild Project Creation
-            project.AddProperty("TargetFrameworks", "net8.0;net9.0");
+            project.AddProperty("TargetFrameworks", "net8.0;net9.0;net10.0");
             customizer?.Invoke(project);
 
             project.Save();


### PR DESCRIPTION
- global.json was updated to 10.0.100
- net10.0 target framework was added
- Latest packages are now used when targeting dotnet10
  - Other packages were updated to the latest version (used when targeting net8 or net9) so we don't get deprecated packages errors.
- Test packages were updated to the latest version
