### PR TITLE
fix: --exclude does not apply filter early enough in the pipeline, potentially resulting in tool failure

### DIFF
--- a/benchmarks/dotnet-affected.Benchmarks/AffectedBenchmark.cs
+++ b/benchmarks/dotnet-affected.Benchmarks/AffectedBenchmark.cs
@@ -42,14 +42,15 @@ namespace Affected.Cli.Benchmarks
             Repository.StageAndCommit();
 
             // Add random files to the tree so that some projects have changes
-            var graph = new ProjectGraph(rootNodes.Select(x => x.FullPath));
-            await Repository.MakeChangesInProjectTree(graph);
+            var options = new AffectedOptions(Repository.Path);
+            var buildResult = new ProjectGraphFactory(options).BuildProjectGraph();
+            await Repository.MakeChangesInProjectTree(buildResult.Graph);
 
-            Console.WriteLine($"Built graph with total of {graph.ProjectNodes.Count()} " +
-                              $"projects in {graph.ConstructionMetrics.ConstructionTime}");
+            Console.WriteLine($"Built graph with total of {buildResult.Graph.ProjectNodes.Count()} " +
+                              $"projects in {buildResult.Graph.ConstructionMetrics.ConstructionTime}");
 
             // Create an executor for the repository using the existing graph.
-            Executor = new AffectedExecutor(Repository.Path, graph);
+            Executor = new AffectedExecutor(options, buildResult);
         }
 
         public AffectedExecutor Executor { get; set; }

--- a/src/DotnetAffected.Abstractions/AffectedSummary.cs
+++ b/src/DotnetAffected.Abstractions/AffectedSummary.cs
@@ -19,7 +19,7 @@ namespace DotnetAffected.Abstractions
             string[] filesThatChanged,
             ProjectGraphNode[] projectsWithChangedFiles,
             ProjectGraphNode[] affectedProjects,
-            ProjectGraphNode[] excludedProjects,
+            string[] excludedProjects,
             PackageChange[] changedPackages)
         {
             FilesThatChanged = filesThatChanged;
@@ -45,9 +45,9 @@ namespace DotnetAffected.Abstractions
         public ProjectGraphNode[] AffectedProjects { get; }
 
         /// <summary>
-        /// Gets a list of projects that had changes or were affected but were excluded from discovery.
+        /// Gets a list of project paths that were excluded from discovery.
         /// </summary>
-        public ProjectGraphNode[] ExcludedProjects { get; }
+        public string[] ExcludedProjects { get; }
 
         /// <summary>
         /// Gets the list of packages that changed.

--- a/src/DotnetAffected.Abstractions/IDiscoveryOptions.cs
+++ b/src/DotnetAffected.Abstractions/IDiscoveryOptions.cs
@@ -15,5 +15,10 @@
         /// This could be any file that the inner <see cref="IProjectDiscoverer"/> supports.
         /// </summary>
         string? FilterFilePath { get; }
+
+        /// <summary>
+        /// Gets the regular expression to use for excluding projects during discovery.
+        /// </summary>
+        string? ExclusionRegex { get; }
     }
 }

--- a/src/DotnetAffected.Core/AffectedExecutor.cs
+++ b/src/DotnetAffected.Core/AffectedExecutor.cs
@@ -1,43 +1,30 @@
 ﻿using DotnetAffected.Abstractions;
 using DotnetAffected.Core.Processor;
-using Microsoft.Build.Graph;
 
 namespace DotnetAffected.Core
 {
     /// <summary>
-    /// Analyzes MSBuild projects in order to determine which projects are affected by a set of changes.
+    /// Analyzes MSBuild projects in order to determine which are affected by a set of changes.
     /// </summary>
     public class AffectedExecutor : IAffectedExecutor
     {
         private readonly AffectedProcessorContext _context;
 
         /// <summary>
-        /// Creates an executor for a repository path and a graph.
-        /// </summary>
-        /// <param name="repositoryPath"></param>
-        /// <param name="graph"></param>
-        public AffectedExecutor(string repositoryPath, ProjectGraph? graph = null)
-            : this(new AffectedOptions(repositoryPath), graph)
-        {
-        }
-
-        /// <summary>
         /// Creates the executor using all parameters.
         /// </summary>
         /// <param name="options"></param>
+        /// <param name="buildResult"></param>
         /// <param name="changesProvider"></param>
-        /// <param name="graph"></param>
         /// <param name="changedProjectsProvider"></param>
-        /// <param name="excludedProjectPaths"></param>
         public AffectedExecutor(
             AffectedOptions options,
-            ProjectGraph? graph = null,
+            ProjectGraphBuildResult buildResult,
             IChangesProvider? changesProvider = null,
-            IChangedProjectsProvider? changedProjectsProvider = null,
-            string[]? excludedProjectPaths = null)
+            IChangedProjectsProvider? changedProjectsProvider = null)
         {
-            _context = new AffectedProcessorContext(options, graph, changesProvider, changedProjectsProvider,
-                excludedProjectPaths);
+            _context = new AffectedProcessorContext(
+                options, buildResult, changesProvider, changedProjectsProvider);
         }
 
         /// <inheritdoc />

--- a/src/DotnetAffected.Core/AffectedExecutor.cs
+++ b/src/DotnetAffected.Core/AffectedExecutor.cs
@@ -28,13 +28,16 @@ namespace DotnetAffected.Core
         /// <param name="changesProvider"></param>
         /// <param name="graph"></param>
         /// <param name="changedProjectsProvider"></param>
+        /// <param name="excludedProjectPaths"></param>
         public AffectedExecutor(
             AffectedOptions options,
             ProjectGraph? graph = null,
             IChangesProvider? changesProvider = null,
-            IChangedProjectsProvider? changedProjectsProvider = null)
+            IChangedProjectsProvider? changedProjectsProvider = null,
+            string[]? excludedProjectPaths = null)
         {
-            _context = new AffectedProcessorContext(options, graph, changesProvider, changedProjectsProvider);
+            _context = new AffectedProcessorContext(options, graph, changesProvider, changedProjectsProvider,
+                excludedProjectPaths);
         }
 
         /// <inheritdoc />

--- a/src/DotnetAffected.Core/Processor/AffectedProcessor.cs
+++ b/src/DotnetAffected.Core/Processor/AffectedProcessor.cs
@@ -105,7 +105,7 @@ namespace DotnetAffected.Core.Processor
                 }
             }
 
-            var relatedProjects = context.Graph.ProjectNodes
+            var relatedProjects = context.BuildResult.Graph.ProjectNodes
                 .Where(node =>
                     changedPackageFiles.Any(f => node.ProjectInstance.FullPath.StartsWith(f.DirectoryName!)));
 

--- a/src/DotnetAffected.Core/Processor/AffectedProcessorBase.cs
+++ b/src/DotnetAffected.Core/Processor/AffectedProcessorBase.cs
@@ -2,7 +2,6 @@
 using Microsoft.Build.Graph;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace DotnetAffected.Core.Processor
 {
@@ -23,28 +22,24 @@ namespace DotnetAffected.Core.Processor
                 .ToArray();
 
             // Map the files that changed to their corresponding project/s.
-            var excludedProjects = new List<ProjectGraphNode>();
-            context.ChangedProjects = ApplyExclusionPattern(
-                DiscoverProjectsForFiles(context),
-                context.Options,
-                excludedProjects);
+            context.ChangedProjects = DiscoverProjectsForFiles(context)
+                .ToArray();
 
             // Get packages that have changed, either from central package management or from the project file
             context.ChangedPackages = DiscoverPackageChanges(context);
 
             // Determine which projects are affected by the projects and packages that have changed.
-            context.AffectedProjects = ApplyExclusionPattern(
-                DiscoverAffectedProjects(context),
-                context.Options,
-                excludedProjects);
+            context.AffectedProjects = DiscoverAffectedProjects(context);
+
+            // Excluded projects are those filtered during graph construction.
+            var excludedProjects = context.ExcludedProjectPaths;
 
             // Output a summary of the operation.
             return new AffectedSummary(
                 context.ChangedFiles,
                 context.ChangedProjects,
                 context.AffectedProjects,
-                excludedProjects.Distinct()
-                    .ToArray(),
+                excludedProjects,
                 context.ChangedPackages);
         }
 
@@ -68,37 +63,6 @@ namespace DotnetAffected.Core.Processor
                            new PredictionChangedProjectsProvider(context.Graph, context.Options);
             // Match which files belong to which of our known projects
             return provider.GetReferencingProjects(context.ChangedFiles);
-        }
-
-        /// <summary>
-        /// Applies the <see cref="AffectedOptions.ExclusionRegex"/> to exclude
-        /// projects that matches the regular expression.
-        /// </summary>
-        /// <param name="inputProjects">List of projects that changed.</param>
-        /// <param name="options">Affected options.</param>
-        /// <param name="excludedProjects">Collection of excluded projects</param>
-        /// <returns>Project lis excluding the ones that matches the exclusion regex.</returns>
-        protected virtual ProjectGraphNode[] ApplyExclusionPattern(
-            IEnumerable<ProjectGraphNode> inputProjects,
-            AffectedOptions options,
-            ICollection<ProjectGraphNode> excludedProjects)
-        {
-            var pattern = options.ExclusionRegex;
-
-            if (string.IsNullOrEmpty(pattern))
-                return inputProjects.ToArray();
-
-            var changedProjects = new List<ProjectGraphNode>();
-            var regex = new Regex(pattern);
-            foreach (var project in inputProjects)
-            {
-                if (regex.IsMatch(project.GetFullPath()))
-                    excludedProjects.Add(project);
-                else
-                    changedProjects.Add(project);
-            }
-
-            return changedProjects.ToArray();
         }
 
         /// <summary>

--- a/src/DotnetAffected.Core/Processor/AffectedProcessorBase.cs
+++ b/src/DotnetAffected.Core/Processor/AffectedProcessorBase.cs
@@ -37,7 +37,7 @@ namespace DotnetAffected.Core.Processor
                 context.ChangedFiles,
                 context.ChangedProjects,
                 context.AffectedProjects,
-                context.ExcludedProjectPaths,
+                context.BuildResult.ExcludedProjectPaths,
                 context.ChangedPackages);
         }
 
@@ -56,9 +56,8 @@ namespace DotnetAffected.Core.Processor
         /// <returns></returns>
         protected virtual IEnumerable<ProjectGraphNode> DiscoverProjectsForFiles(AffectedProcessorContext context)
         {
-            // We init now because we want the graph to initialize late (lazy)
             var provider = context.ChangedProjectsProvider ??
-                           new PredictionChangedProjectsProvider(context.Graph, context.Options);
+                           new PredictionChangedProjectsProvider(context.BuildResult.Graph, context.Options);
             // Match which files belong to which of our known projects
             return provider.GetReferencingProjects(context.ChangedFiles);
         }

--- a/src/DotnetAffected.Core/Processor/AffectedProcessorBase.cs
+++ b/src/DotnetAffected.Core/Processor/AffectedProcessorBase.cs
@@ -32,14 +32,12 @@ namespace DotnetAffected.Core.Processor
             context.AffectedProjects = DiscoverAffectedProjects(context);
 
             // Excluded projects are those filtered during graph construction.
-            var excludedProjects = context.ExcludedProjectPaths;
-
             // Output a summary of the operation.
             return new AffectedSummary(
                 context.ChangedFiles,
                 context.ChangedProjects,
                 context.AffectedProjects,
-                excludedProjects,
+                context.ExcludedProjectPaths,
                 context.ChangedPackages);
         }
 

--- a/src/DotnetAffected.Core/Processor/AffectedProcessorContext.cs
+++ b/src/DotnetAffected.Core/Processor/AffectedProcessorContext.cs
@@ -11,9 +11,6 @@ namespace DotnetAffected.Core.Processor
     /// </summary>
     internal class AffectedProcessorContext
     {
-        private ProjectGraph? _graph;
-        private string[]? _excludedProjectPaths;
-
         /// <inheritdoc cref="IChangesProvider"/>
         public IChangesProvider ChangesProvider { get; }
 
@@ -33,34 +30,12 @@ namespace DotnetAffected.Core.Processor
         public IChangedProjectsProvider? ChangedProjectsProvider { get; }
 
         /// <inheritdoc cref="ProjectGraph"/>
-        public ProjectGraph Graph
-        {
-            get
-            {
-                if (_graph == null)
-                {
-                    var result = new ProjectGraphFactory(Options).BuildProjectGraph();
-                    _graph = result.Graph;
-                    _excludedProjectPaths = result.ExcludedProjectPaths;
-                }
-
-                return _graph;
-            }
-        }
+        public ProjectGraph Graph { get; }
 
         /// <summary>
         /// Gets the project paths that were excluded during graph construction.
-        /// Accessing this property will trigger graph construction if not already built.
         /// </summary>
-        internal string[] ExcludedProjectPaths
-        {
-            get
-            {
-                // Ensure the graph is built so excluded paths are populated
-                _ = Graph;
-                return _excludedProjectPaths ?? Array.Empty<string>();
-            }
-        }
+        internal string[] ExcludedProjectPaths { get; }
 
         internal string[] ChangedFiles { get; set; } = Array.Empty<string>();
         internal ProjectGraphNode[] ChangedProjects { get; set; } = Array.Empty<ProjectGraphNode>();
@@ -72,20 +47,18 @@ namespace DotnetAffected.Core.Processor
         ///
         /// </summary>
         /// <param name="options"></param>
-        /// <param name="graph"></param>
+        /// <param name="buildResult"></param>
         /// <param name="changesProvider"></param>
         /// <param name="changedProjectsProvider"></param>
-        /// <param name="excludedProjectPaths"></param>
         public AffectedProcessorContext(AffectedOptions options,
-            ProjectGraph? graph = null,
+            ProjectGraphBuildResult buildResult,
             IChangesProvider? changesProvider = null,
-            IChangedProjectsProvider? changedProjectsProvider = null,
-            string[]? excludedProjectPaths = null)
+            IChangedProjectsProvider? changedProjectsProvider = null)
         {
             ChangesProvider = changesProvider ?? new GitChangesProvider();
             Options = options;
-            _graph = graph;
-            _excludedProjectPaths = excludedProjectPaths;
+            Graph = buildResult.Graph;
+            ExcludedProjectPaths = buildResult.ExcludedProjectPaths;
             ChangedProjectsProvider = changedProjectsProvider;
 
             RepositoryPath = Path.TrimEndingDirectorySeparator(options.RepositoryPath);

--- a/src/DotnetAffected.Core/Processor/AffectedProcessorContext.cs
+++ b/src/DotnetAffected.Core/Processor/AffectedProcessorContext.cs
@@ -29,13 +29,8 @@ namespace DotnetAffected.Core.Processor
         /// <inheritdoc cref="IChangedProjectsProvider"/>
         public IChangedProjectsProvider? ChangedProjectsProvider { get; }
 
-        /// <inheritdoc cref="ProjectGraph"/>
-        public ProjectGraph Graph { get; }
-
-        /// <summary>
-        /// Gets the project paths that were excluded during graph construction.
-        /// </summary>
-        internal string[] ExcludedProjectPaths { get; }
+        /// <inheritdoc cref="ProjectGraphBuildResult"/>
+        public ProjectGraphBuildResult BuildResult { get; }
 
         internal string[] ChangedFiles { get; set; } = Array.Empty<string>();
         internal ProjectGraphNode[] ChangedProjects { get; set; } = Array.Empty<ProjectGraphNode>();
@@ -57,8 +52,7 @@ namespace DotnetAffected.Core.Processor
         {
             ChangesProvider = changesProvider ?? new GitChangesProvider();
             Options = options;
-            Graph = buildResult.Graph;
-            ExcludedProjectPaths = buildResult.ExcludedProjectPaths;
+            BuildResult = buildResult;
             ChangedProjectsProvider = changedProjectsProvider;
 
             RepositoryPath = Path.TrimEndingDirectorySeparator(options.RepositoryPath);

--- a/src/DotnetAffected.Core/Processor/AffectedProcessorContext.cs
+++ b/src/DotnetAffected.Core/Processor/AffectedProcessorContext.cs
@@ -12,6 +12,7 @@ namespace DotnetAffected.Core.Processor
     internal class AffectedProcessorContext
     {
         private ProjectGraph? _graph;
+        private string[]? _excludedProjectPaths;
 
         /// <inheritdoc cref="IChangesProvider"/>
         public IChangesProvider ChangesProvider { get; }
@@ -32,7 +33,34 @@ namespace DotnetAffected.Core.Processor
         public IChangedProjectsProvider? ChangedProjectsProvider { get; }
 
         /// <inheritdoc cref="ProjectGraph"/>
-        public ProjectGraph Graph => _graph ??= new ProjectGraphFactory(Options).BuildProjectGraph();
+        public ProjectGraph Graph
+        {
+            get
+            {
+                if (_graph == null)
+                {
+                    var result = new ProjectGraphFactory(Options).BuildProjectGraph();
+                    _graph = result.Graph;
+                    _excludedProjectPaths = result.ExcludedProjectPaths;
+                }
+
+                return _graph;
+            }
+        }
+
+        /// <summary>
+        /// Gets the project paths that were excluded during graph construction.
+        /// Accessing this property will trigger graph construction if not already built.
+        /// </summary>
+        internal string[] ExcludedProjectPaths
+        {
+            get
+            {
+                // Ensure the graph is built so excluded paths are populated
+                _ = Graph;
+                return _excludedProjectPaths ?? Array.Empty<string>();
+            }
+        }
 
         internal string[] ChangedFiles { get; set; } = Array.Empty<string>();
         internal ProjectGraphNode[] ChangedProjects { get; set; } = Array.Empty<ProjectGraphNode>();
@@ -41,20 +69,23 @@ namespace DotnetAffected.Core.Processor
         internal Dictionary<object, object> Data { get; } = new Dictionary<object, object>();
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="options"></param>
         /// <param name="graph"></param>
         /// <param name="changesProvider"></param>
         /// <param name="changedProjectsProvider"></param>
+        /// <param name="excludedProjectPaths"></param>
         public AffectedProcessorContext(AffectedOptions options,
             ProjectGraph? graph = null,
             IChangesProvider? changesProvider = null,
-            IChangedProjectsProvider? changedProjectsProvider = null)
+            IChangedProjectsProvider? changedProjectsProvider = null,
+            string[]? excludedProjectPaths = null)
         {
             ChangesProvider = changesProvider ?? new GitChangesProvider();
             Options = options;
             _graph = graph;
+            _excludedProjectPaths = excludedProjectPaths;
             ChangedProjectsProvider = changedProjectsProvider;
 
             RepositoryPath = Path.TrimEndingDirectorySeparator(options.RepositoryPath);

--- a/src/DotnetAffected.Core/ProjectGraphFactory.cs
+++ b/src/DotnetAffected.Core/ProjectGraphFactory.cs
@@ -1,8 +1,36 @@
 ﻿using DotnetAffected.Abstractions;
 using Microsoft.Build.Graph;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace DotnetAffected.Core
 {
+    /// <summary>
+    /// The result of building a <see cref="ProjectGraph"/>.
+    /// </summary>
+    public class ProjectGraphBuildResult
+    {
+        /// <summary>
+        /// Gets the built project graph.
+        /// </summary>
+        public ProjectGraph Graph { get; }
+
+        /// <summary>
+        /// Gets the paths of projects that were excluded during graph construction.
+        /// </summary>
+        public string[] ExcludedProjectPaths { get; }
+
+        /// <summary>
+        /// Creates a new instance.
+        /// </summary>
+        public ProjectGraphBuildResult(ProjectGraph graph, string[] excludedProjectPaths)
+        {
+            Graph = graph;
+            ExcludedProjectPaths = excludedProjectPaths;
+        }
+    }
+
     /// <summary>
     /// Resolves the <see cref="ProjectGraph"/> for the directory provided in user input.
     /// </summary>
@@ -20,24 +48,43 @@ namespace DotnetAffected.Core
         }
 
         /// <summary>
-        /// Builds a <see cref="ProjectGraph"/> from all discovered projects.
+        /// Builds a <see cref="ProjectGraph"/> from all discovered projects,
+        /// applying exclusion filters before graph construction.
         /// </summary>
-        /// <returns>A new Project Graph.</returns>
-        public ProjectGraph BuildProjectGraph()
+        /// <returns>A build result containing the graph and any excluded project paths.</returns>
+        public ProjectGraphBuildResult BuildProjectGraph()
         {
             // Discover all projects and build the graph
             var allProjects = new ProjectDiscoveryManager()
                 .DiscoverProjects(_options);
 
+            // Apply exclusion filter before building the graph
+            var excludedPaths = new List<string>();
+            var pattern = _options.ExclusionRegex;
+            if (!string.IsNullOrEmpty(pattern))
+            {
+                var regex = new Regex(pattern);
+                var included = new List<string>();
+                foreach (var project in allProjects)
+                {
+                    if (regex.IsMatch(project))
+                        excludedPaths.Add(project);
+                    else
+                        included.Add(project);
+                }
+
+                allProjects = included;
+            }
+
             WriteLine($"Building Dependency Graph");
 
-            var output = new ProjectGraph(allProjects);
+            var graph = new ProjectGraph(allProjects);
 
             WriteLine(
-                $"Built Graph with {output.ConstructionMetrics.NodeCount} Projects " +
-                $"in {output.ConstructionMetrics.ConstructionTime:s\\.ff}s");
+                $"Built Graph with {graph.ConstructionMetrics.NodeCount} Projects " +
+                $"in {graph.ConstructionMetrics.ConstructionTime:s\\.ff}s");
 
-            return output;
+            return new ProjectGraphBuildResult(graph, excludedPaths.ToArray());
         }
 
         private void WriteLine(string? message = null)

--- a/src/DotnetAffected.Core/ProjectGraphFactory.cs
+++ b/src/DotnetAffected.Core/ProjectGraphFactory.cs
@@ -9,27 +9,15 @@ namespace DotnetAffected.Core
     /// <summary>
     /// The result of building a <see cref="ProjectGraph"/>.
     /// </summary>
-    public class ProjectGraphBuildResult
-    {
-        /// <summary>
-        /// Gets the built project graph.
-        /// </summary>
-        public ProjectGraph Graph { get; }
-
-        /// <summary>
-        /// Gets the paths of projects that were excluded during graph construction.
-        /// </summary>
-        public string[] ExcludedProjectPaths { get; }
-
-        /// <summary>
-        /// Creates a new instance.
-        /// </summary>
-        public ProjectGraphBuildResult(ProjectGraph graph, string[] excludedProjectPaths)
-        {
-            Graph = graph;
-            ExcludedProjectPaths = excludedProjectPaths;
-        }
-    }
+    /// <paramref name="Graph">
+    /// Gets the built project graph.
+    /// </paramref>
+    /// <paramref name="ExcludedProjectPaths">
+    /// Gets the paths of projects that were excluded during graph construction.
+    /// </paramref>
+    public record ProjectGraphBuildResult(
+        ProjectGraph Graph,
+        string[] ExcludedProjectPaths);
 
     /// <summary>
     /// Resolves the <see cref="ProjectGraph"/> for the directory provided in user input.

--- a/src/DotnetAffected.Tasks/AffectedTask.cs
+++ b/src/DotnetAffected.Tasks/AffectedTask.cs
@@ -55,10 +55,9 @@ namespace DotnetAffected.Tasks
                     : new GitChangesProvider();
 
                 var executor = new AffectedExecutor(affectedOptions,
-                    buildResult.Graph,
+                    buildResult,
                     changesProvider,
-                    new PredictionChangedProjectsProvider(buildResult.Graph, affectedOptions),
-                    buildResult.ExcludedProjectPaths);
+                    new PredictionChangedProjectsProvider(buildResult.Graph, affectedOptions));
 
                 var results = executor.Execute();
                 var modifiedProjectInstances = new HashSet<ProjectInstance>();

--- a/src/DotnetAffected.Tasks/AffectedTask.cs
+++ b/src/DotnetAffected.Tasks/AffectedTask.cs
@@ -48,16 +48,17 @@ namespace DotnetAffected.Tasks
                         "DotnetAffected AssumeChanges is set along with FromRef/ToRef. Only AssumeChanges is used.");
                 }
 
-                var graph = new ProjectGraphFactory(affectedOptions).BuildProjectGraph();
+                var buildResult = new ProjectGraphFactory(affectedOptions).BuildProjectGraph();
                 IChangesProvider changesProvider = AssumeChanges?.Any() == true
-                    ? new AssumptionChangesProvider(graph,
+                    ? new AssumptionChangesProvider(buildResult.Graph,
                         AssumeChanges.Select(c => Path.GetFileNameWithoutExtension(c.ItemSpec)))
                     : new GitChangesProvider();
 
                 var executor = new AffectedExecutor(affectedOptions,
-                    graph,
+                    buildResult.Graph,
                     changesProvider,
-                    new PredictionChangedProjectsProvider(graph, affectedOptions));
+                    new PredictionChangedProjectsProvider(buildResult.Graph, affectedOptions),
+                    buildResult.ExcludedProjectPaths);
 
                 var results = executor.Execute();
                 var modifiedProjectInstances = new HashSet<ProjectInstance>();

--- a/src/dotnet-affected/Commands/Binding/InvocationContextExtensions.cs
+++ b/src/dotnet-affected/Commands/Binding/InvocationContextExtensions.cs
@@ -24,10 +24,9 @@ namespace Affected.Cli.Commands
                 : new GitChangesProvider();
 
             var executor = new AffectedExecutor(options,
-                buildResult.Graph,
+                buildResult,
                 changesProvider,
-                new PredictionChangedProjectsProvider(buildResult.Graph, options),
-                buildResult.ExcludedProjectPaths);
+                new PredictionChangedProjectsProvider(buildResult.Graph, options));
 
             return (executor, options);
         }

--- a/src/dotnet-affected/Commands/Binding/InvocationContextExtensions.cs
+++ b/src/dotnet-affected/Commands/Binding/InvocationContextExtensions.cs
@@ -15,18 +15,19 @@ namespace Affected.Cli.Commands
             var assumeChanges = ctx.ParseResult.GetValueForOption(AffectedGlobalOptions.AssumeChangesOption);
 
             var options = ctx.GetAffectedOptions();
-            var graph = new ProjectGraphFactory(options).BuildProjectGraph();
+            var buildResult = new ProjectGraphFactory(options).BuildProjectGraph();
 
             var assumptions = assumeChanges?.ToArray() ?? Array.Empty<string>();
 
             IChangesProvider changesProvider = assumptions.Any()
-                ? new AssumptionChangesProvider(graph, assumptions)
+                ? new AssumptionChangesProvider(buildResult.Graph, assumptions)
                 : new GitChangesProvider();
 
             var executor = new AffectedExecutor(options,
-                graph,
+                buildResult.Graph,
                 changesProvider,
-                new PredictionChangedProjectsProvider(graph, options));
+                new PredictionChangedProjectsProvider(buildResult.Graph, options),
+                buildResult.ExcludedProjectPaths);
 
             return (executor, options);
         }

--- a/src/dotnet-affected/Views/NoChangesView.cs
+++ b/src/dotnet-affected/Views/NoChangesView.cs
@@ -5,7 +5,7 @@ namespace Affected.Cli.Views
     internal class NoChangesView : ContentView
     {
         public NoChangesView()
-            : base("No affected projects where found for the current changes")
+            : base("No affected projects were found for the current changes")
         {
         }
     }

--- a/src/dotnet-affected/Views/ProjectInfoTable.cs
+++ b/src/dotnet-affected/Views/ProjectInfoTable.cs
@@ -8,8 +8,13 @@ namespace Affected.Cli.Views
     internal sealed class ProjectInfoTable : TableView<IProjectInfo>
     {
         public ProjectInfoTable(IEnumerable<ProjectGraphNode> nodes)
+            : this(nodes.Select(p => new ProjectInfo(p)))
         {
-            this.Items = nodes.Select(p => new ProjectInfo(p))
+        }
+
+        public ProjectInfoTable(IEnumerable<IProjectInfo> projects)
+        {
+            this.Items = projects
                 .OrderBy(x => x.Name)
                 .ToList();
             this.AddColumn(p => p.Name, "Name");

--- a/src/dotnet-affected/Views/WithChangesAndAffectedView.cs
+++ b/src/dotnet-affected/Views/WithChangesAndAffectedView.cs
@@ -37,7 +37,8 @@ namespace Affected.Cli.Views
             if (summary.ExcludedProjects.Any())
             {
                 Add(new ContentView("\nExcluded Projects"));
-                Add(new ProjectInfoTable(summary.ExcludedProjects));
+                Add(new ProjectInfoTable(summary.ExcludedProjects.Select(p =>
+                    new ProjectInfo(System.IO.Path.GetFileNameWithoutExtension(p), p))));
             }
         }
     }

--- a/src/dotnet-affected/Views/WithChangesAndAffectedView.cs
+++ b/src/dotnet-affected/Views/WithChangesAndAffectedView.cs
@@ -1,5 +1,6 @@
 using DotnetAffected.Abstractions;
 using System.CommandLine.Rendering.Views;
+using System.IO;
 using System.Linq;
 
 namespace Affected.Cli.Views
@@ -32,13 +33,13 @@ namespace Affected.Cli.Views
             if (summary.AffectedProjects.Any())
                 Add(new ProjectInfoTable(summary.AffectedProjects));
             else
-                Add(new ContentView("No projects where affected by any of the changed projects."));
+                Add(new ContentView("No projects were affected by any of the changed projects."));
 
             if (summary.ExcludedProjects.Any())
             {
                 Add(new ContentView("\nExcluded Projects"));
                 Add(new ProjectInfoTable(summary.ExcludedProjects.Select(p =>
-                    new ProjectInfo(System.IO.Path.GetFileNameWithoutExtension(p), p))));
+                    new ProjectInfo(Path.GetFileNameWithoutExtension(p), p))));
             }
         }
     }

--- a/test/DotnetAffected.Core.Tests/AssumeChangesTests.cs
+++ b/test/DotnetAffected.Core.Tests/AssumeChangesTests.cs
@@ -18,12 +18,12 @@ namespace DotnetAffected.Core.Tests
             this._affectedSummaryLazy = new Lazy<AffectedSummary>(() =>
             {
                 var factory = new ProjectGraphFactory(options);
-                var graph = factory.BuildProjectGraph();
-                var changesProvider = new AssumptionChangesProvider(graph, new[]
+                var buildResult = factory.BuildProjectGraph();
+                var changesProvider = new AssumptionChangesProvider(buildResult.Graph, new[]
                 {
                     _projectName
                 });
-                var executor = new AffectedExecutor(options, graph, changesProvider);
+                var executor = new AffectedExecutor(options, buildResult.Graph, changesProvider);
                 return executor.Execute();
             });
         }

--- a/test/DotnetAffected.Core.Tests/AssumeChangesTests.cs
+++ b/test/DotnetAffected.Core.Tests/AssumeChangesTests.cs
@@ -23,7 +23,7 @@ namespace DotnetAffected.Core.Tests
                 {
                     _projectName
                 });
-                var executor = new AffectedExecutor(options, buildResult.Graph, changesProvider);
+                var executor = new AffectedExecutor(options, buildResult, changesProvider);
                 return executor.Execute();
             });
         }

--- a/test/DotnetAffected.Core.Tests/ChangedProjectsPredictorTests.cs
+++ b/test/DotnetAffected.Core.Tests/ChangedProjectsPredictorTests.cs
@@ -14,7 +14,7 @@ namespace DotnetAffected.Core.Tests
 
         private IChangedProjectsProvider Provider => new PredictionChangedProjectsProvider(Graph, Options);
 
-        private ProjectGraph Graph => _graph ??= new ProjectGraphFactory(Options).BuildProjectGraph();
+        private ProjectGraph Graph => _graph ??= new ProjectGraphFactory(Options).BuildProjectGraph().Graph;
 
         [Fact]
         public async Task FindProjectsForFilePaths_ShouldFindSingleProject()

--- a/test/DotnetAffected.Core.Tests/ProjectExclusionTests.cs
+++ b/test/DotnetAffected.Core.Tests/ProjectExclusionTests.cs
@@ -39,7 +39,8 @@ namespace DotnetAffected.Core.Tests
             Assert.Empty(AffectedSummary.ProjectsWithChangedFiles);
             Assert.Empty(AffectedSummary.AffectedProjects);
 
-            Assert.Single(AffectedSummary.ExcludedProjects);
+            // Both InventoryManagement and InventoryManagement.Tests are excluded at discovery
+            Assert.Equal(2, AffectedSummary.ExcludedProjects.Length);
         }
 
         [Fact]
@@ -83,7 +84,8 @@ namespace DotnetAffected.Core.Tests
             Assert.Equal(dependantProjectName, affectedProject.GetProjectName());
             Assert.Equal(dependantMsBuildProject.FullPath, affectedProject.GetFullPath());
 
-            Assert.Single(AffectedSummary.ExcludedProjects);
+            // All three Inventory* projects are excluded at discovery
+            Assert.Equal(3, AffectedSummary.ExcludedProjects.Length);
         }
 
         [Fact]

--- a/test/DotnetAffected.Core.Tests/Utils/BaseDotnetAffectedTest.cs
+++ b/test/DotnetAffected.Core.Tests/Utils/BaseDotnetAffectedTest.cs
@@ -12,7 +12,8 @@ namespace DotnetAffected.Core.Tests
         {
             this._affectedSummaryLazy = new Lazy<AffectedSummary>(() =>
             {
-                var executor = new AffectedExecutor(Options, changesProvider: ChangesProvider);
+                var buildResult = new ProjectGraphFactory(Options).BuildProjectGraph();
+                var executor = new AffectedExecutor(Options, buildResult, ChangesProvider);
                 return executor.Execute();
             });
         }

--- a/test/dotnet-affected.Tests/AffectedCommandTests.cs
+++ b/test/dotnet-affected.Tests/AffectedCommandTests.cs
@@ -65,7 +65,7 @@ namespace Affected.Cli.Tests
 
             Assert.Contains($"WRITE: {Path.Combine(Repository.Path, "affected.txt")}", output);
             Assert.Contains(projectName, output);
-            Assert.Contains("No projects where affected by any of the changed projects.", output);
+            Assert.Contains("No projects were affected by any of the changed projects.", output);
         }
 
         [Fact]
@@ -99,7 +99,7 @@ namespace Affected.Cli.Tests
 
             Assert.Equal(AffectedExitCodes.NothingChanged, exitCode);
 
-            Assert.Contains($"No affected projects where found for the current changes", output);
+            Assert.Contains($"No affected projects were found for the current changes", output);
         }
 
         [Fact]


### PR DESCRIPTION
Please note that this PR was created with LLM assistance; feel free to reject if this is against project guidelines.

---

The --exclude regex filter was only applied after the ProjectGraph was built, meaning MSBuild would still evaluate excluded projects during graph construction. This caused failures for projects that MSBuild cannot process, e.g. .sqlproj.

Moved exclusion filtering into ProjectGraphFactory.BuildProjectGraph() so that matching projects are removed before being passed to the ProjectGraph constructor. This also changes AffectedSummary.ExcludedProjects from ProjectGraphNode[] to string[] since excluded projects are never built into these nodes.

Because AffectedProcessorContext now has to be cognisant of both the graph and excluded projects, it wasn't practical to continue with the lazy Graph property, so this was replaced with the ProjectGraphBuildResult that needs to be provided upon construction. Since this was effectively already done in all cases except tests, the impact of this refactoring was relatively minimal.

Closes #146