### PR TITLE
feat: add solution filter file output

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ dotnet-affected currently supports following **format options**:
 - `traversal`: Traversal SDK project file.
 - `text`: Plain text file containing all affected project paths.
 - `json`: JSON file containing all affected project names and paths.
+- `slnf`: [Solution Filter](https://learn.microsoft.com/en-us/visualstudio/msbuild/solution-filters) JSON file containing Solution name and affected project paths.
 
 Example:
 ```text

--- a/src/dotnet-affected/Commands/AffectedRootCommand.cs
+++ b/src/dotnet-affected/Commands/AffectedRootCommand.cs
@@ -61,6 +61,7 @@ namespace Affected.Cli.Commands
                     outputOptions.Formatters,
                     outputOptions.OutputDir,
                     outputOptions.OutputName,
+                    options.FilterFilePath,
                     outputOptions.DryRun,
                     verbose);
             });
@@ -75,7 +76,7 @@ namespace Affected.Cli.Commands
                 "--format", "-f"
             })
         {
-            this.Description = "Space-seperated output file formats. Possible values: <traversal, text, json>.";
+            this.Description = "Space-seperated output file formats. Possible values: <traversal, text, json, slnf>.";
 
             this.SetDefaultValue(new[]
             {

--- a/src/dotnet-affected/Domain/IOutputFormatter.cs
+++ b/src/dotnet-affected/Domain/IOutputFormatter.cs
@@ -26,6 +26,6 @@ namespace Affected.Cli
         /// </summary>
         /// <param name="projects">List of projects to format.</param>
         /// <returns>The formatted output.</returns>
-        Task<string> Format(IEnumerable<IProjectInfo> projects);
+        Task<string> Format(IEnumerable<IProjectInfo> projects, string? filterFilePath = null);
     }
 }

--- a/src/dotnet-affected/Infrastructure/Formatters/JsonOutputFormatter.cs
+++ b/src/dotnet-affected/Infrastructure/Formatters/JsonOutputFormatter.cs
@@ -15,7 +15,7 @@ namespace Affected.Cli.Formatters
             WriteIndented = true
         };
 
-        public Task<string> Format(IEnumerable<IProjectInfo> projects)
+        public Task<string> Format(IEnumerable<IProjectInfo> projects, string? filterFilePath = null)
         {
             return Task.FromResult(JsonSerializer.Serialize(projects, SerializerOptions));
         }

--- a/src/dotnet-affected/Infrastructure/Formatters/SolutionFilterFileOutputFormatter.cs
+++ b/src/dotnet-affected/Infrastructure/Formatters/SolutionFilterFileOutputFormatter.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Affected.Cli.Formatters
+{
+    internal class SolutionFilterFileOutputFormatter : IOutputFormatter
+    {
+        public string Type => "slnf";
+
+        public string NewFileExtension => ".slnf";
+
+        public static readonly JsonSerializerOptions SerializerOptions = new()
+        {
+            WriteIndented = true
+        };
+
+        public Task<string> Format(IEnumerable<IProjectInfo> projects, string? filterFilePath = null)
+        {
+            if (filterFilePath == null)
+            {
+                throw new ArgumentException("Path to Solution cannot be null for SolutionFilterFile output", "filterFilePath");
+            }
+
+            // Grab the directory the solutionLives in as all project references must be relative to the solution file
+            string solutionDir = Path.GetDirectoryName(filterFilePath);
+
+            IEnumerable<string> projectPaths = projects.Select(p => Path.GetRelativePath(solutionDir, p.FilePath));
+            var solutionFilter = new SolutionFilter(new Solution(filterFilePath, projectPaths));
+            return Task.FromResult(JsonSerializer.Serialize(solutionFilter, SerializerOptions));
+        }
+
+    }
+
+    record SolutionFilter(Solution solution);
+    record Solution(string path, IEnumerable<string> projects);
+}

--- a/src/dotnet-affected/Infrastructure/Formatters/TextOutputFormatter.cs
+++ b/src/dotnet-affected/Infrastructure/Formatters/TextOutputFormatter.cs
@@ -10,7 +10,7 @@ namespace Affected.Cli.Formatters
         
         public string NewFileExtension => ".txt";
 
-        public Task<string> Format(IEnumerable<IProjectInfo> projects)
+        public Task<string> Format(IEnumerable<IProjectInfo> projects, string? filterFilePath = null)
         {
             var builder = new StringBuilder();
 

--- a/src/dotnet-affected/Infrastructure/Formatters/TraversalProjectOutputFormatter.cs
+++ b/src/dotnet-affected/Infrastructure/Formatters/TraversalProjectOutputFormatter.cs
@@ -13,7 +13,7 @@ namespace Affected.Cli.Formatters
         public string Type => "traversal";
         public string NewFileExtension => ".proj";
 
-        public Task<string> Format(IEnumerable<IProjectInfo> projects)
+        public Task<string> Format(IEnumerable<IProjectInfo> projects, string? filterFilePath = null)
         {
             var projectRootElement = @"<Project Sdk=""Microsoft.Build.Traversal/4.1.82""></Project>";
             var stringReader = new StringReader(projectRootElement);

--- a/src/dotnet-affected/Infrastructure/OutputFormatterExecutor.cs
+++ b/src/dotnet-affected/Infrastructure/OutputFormatterExecutor.cs
@@ -30,6 +30,7 @@ namespace Affected.Cli
             IEnumerable<string> formatters,
             string outputDirectory,
             string outputName,
+            string? filterFilePath,
             bool dryRun,
             bool verbose = false)
         {
@@ -50,7 +51,7 @@ namespace Affected.Cli
                 }
 
                 // Format the projects and calculate output path.
-                var outputContents = await formatter.Format(allProjects);
+                var outputContents = await formatter.Format(allProjects, filterFilePath);
 
                 if (string.IsNullOrWhiteSpace(outputContents))
                 {

--- a/src/dotnet-affected/Infrastructure/OutputFormatters.cs
+++ b/src/dotnet-affected/Infrastructure/OutputFormatters.cs
@@ -6,7 +6,7 @@ namespace Affected.Cli
     {
         public static readonly IOutputFormatter[] All =
         {
-            new TextOutputFormatter(), new TraversalProjectOutputFormatter(), new JsonOutputFormatter()
+            new TextOutputFormatter(), new TraversalProjectOutputFormatter(), new JsonOutputFormatter(), new SolutionFilterFileOutputFormatter()
         };
     }
 }

--- a/test/dotnet-affected.Tests/Formatters/FormatterExecutorTests.cs
+++ b/test/dotnet-affected.Tests/Formatters/FormatterExecutorTests.cs
@@ -33,7 +33,7 @@ namespace Affected.Cli.Tests.Formatters
             await executor.Execute(projects, new[]
             {
                 formatterType
-            }, Repository.Path, "affected", false, true);
+            }, Repository.Path, "affected", null, false, true);
 
             var outputPath = Path.Combine(Repository.Path, "affected.txt");
             var outputContents = await File.ReadAllTextAsync(outputPath);
@@ -63,7 +63,7 @@ namespace Affected.Cli.Tests.Formatters
             await executor.Execute(projects, new[]
             {
                 formatterType
-            }, Repository.Path, outputFileName, false, true);
+            }, Repository.Path, outputFileName, null, false, true);
 
             // Assert
             var outputPath = Path.Combine(Repository.Path, $"{outputFileName}.txt");

--- a/test/dotnet-affected.Tests/Formatters/SolutionFilterFileFormatterTests.cs
+++ b/test/dotnet-affected.Tests/Formatters/SolutionFilterFileFormatterTests.cs
@@ -1,0 +1,79 @@
+﻿using Affected.Cli.Formatters;
+using DotnetAffected.Testing.Utils;
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Affected.Cli.Tests.Formatters
+{
+    public class SolutionFilterFileFormatterTests : BaseMSBuildTest
+    {
+        [Fact]
+        public async Task Using_no_solution_should_fail()
+        {
+            var formatter = new SolutionFilterFileOutputFormatter();
+            var projects = new[]
+            {
+                  new ProjectInfo("TestProject", "/home/dev/test/test.csproj")
+            };
+
+            await Assert.ThrowsAsync<ArgumentException>(async () => await formatter.Format(projects, null));
+        }
+
+        [Fact]
+        public async Task Using_single_project_should_contain_it()
+        {
+            var formatter = new SolutionFilterFileOutputFormatter();
+
+            var solutionFile = "/home/dev/Test.slnx";
+            var firstProjectPath = "/home/dev/test/test.csproj";
+            var projects = new[]
+            {
+              new ProjectInfo("TestProject", firstProjectPath)
+          };
+
+            var output = await formatter.Format(projects, solutionFile);
+
+            var solution = new
+            {
+                solution = new
+                {
+                    path = solutionFile,
+                    projects = new[] { Path.GetRelativePath("/home/dev", firstProjectPath) }
+                }
+            };
+
+            Assert.Equal(JsonSerializer.Serialize(solution, SolutionFilterFileOutputFormatter.SerializerOptions), output);
+
+        }
+
+        [Fact]
+        public async Task Using_multiple_project_should_contain_them_all()
+        {
+            var formatter = new SolutionFilterFileOutputFormatter();
+
+            var solutionFile = "/home/AltTest.slnx";
+            var firstProjectPath = "/home/dev/test/proj.csproj";
+            var secondProjectPath = "/home/dev/other-test/other-proj.csproj";
+            var projects = new[]
+            {
+              new ProjectInfo("TestProject", firstProjectPath), new ProjectInfo("OtherTest", secondProjectPath)
+          };
+
+            var output = await formatter.Format(projects, solutionFile);
+
+            var solution = new
+            {
+                solution = new
+                {
+                    path = solutionFile,
+                    projects = new[] { Path.GetRelativePath("/home/", firstProjectPath), Path.GetRelativePath("/home/", secondProjectPath) }
+                }
+            };
+
+            Assert.Equal(JsonSerializer.Serialize(solution, SolutionFilterFileOutputFormatter.SerializerOptions), output);
+        }
+    }
+}


### PR DESCRIPTION
Sorry for the delay in getting this first draft out

I originally tried to refactor things into the form you had suggested in https://github.com/leonardochaia/dotnet-affected/issues/148#issuecomment-3998582336 but that lead to a lot of repeat work where the projects were being re-discovered. It also didn't fully wire up what I needed to as the options set between `AffectedOptions` and `AffectedCommandOutputOptions` were different.

The one complication when writing this was that filter files need to match the same path as the solution file. While it's not guaranteed it would generally be inappropriate to put absolute paths in a Solution file (as it wouldn't be portable) so getting the relative path from the solution file passed in seemed to be an approach that worked consistently.

Happy to make any changes you'd like to this.

Closes #148 