### PR TITLE
fix(prediction): attribute deleted files to their containing project

### DIFF
--- a/src/DotnetAffected.Core/Prediction/PredictionChangedProjectsProvider.cs
+++ b/src/DotnetAffected.Core/Prediction/PredictionChangedProjectsProvider.cs
@@ -2,6 +2,7 @@
 using Microsoft.Build.Graph;
 using Microsoft.Build.Prediction;
 using Microsoft.Build.Prediction.Predictors;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -15,6 +16,13 @@ namespace DotnetAffected.Core
     public class PredictionChangedProjectsProvider : IChangedProjectsProvider
     {
         private readonly ProjectGraph _graph;
+
+        /// <summary>
+        /// File systems on Windows are case insensitive, everywhere else they are not.
+        /// </summary>
+        private static readonly StringComparison PathComparison = GitChangesProvider.IsWindows
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
 
         private static readonly ProjectFileAndImportsGraphPredictor[] GraphPredictors = new[]
         {
@@ -76,16 +84,64 @@ namespace DotnetAffected.Core
             {
                 // determine nodes depending on the changed file
                 var nodesWithFiles = collector.PredictionsPerNode
-                    .Where(x => x.Value.Contains(file));
+                    .Where(x => x.Value.Contains(file))
+                    .Select(x => x.Key)
+                    .ToList();
 
-                foreach (var (key, _) in nodesWithFiles)
+                // A deleted file is gone from disk, so it is no longer an input of any
+                // project in the current graph and no predictor can claim it. Fall back
+                // to the project whose directory contained it, otherwise the owning
+                // project is silently left out of the build.
+                // See https://github.com/leonardochaia/dotnet-affected/issues/84
+                if (nodesWithFiles.Count == 0 && !File.Exists(file))
                 {
-                    if (hasReturned.Add(key.ProjectInstance.FullPath))
+                    var containingNode = FindDeepestProjectContaining(file);
+                    if (containingNode is not null)
                     {
-                        yield return key;
+                        nodesWithFiles.Add(containingNode);
+                    }
+                }
+
+                foreach (var node in nodesWithFiles)
+                {
+                    if (hasReturned.Add(node.ProjectInstance.FullPath))
+                    {
+                        yield return node;
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Finds the project whose directory contains <paramref name="file"/>.
+        /// The deepest directory wins, so nested projects attribute to the innermost one.
+        /// </summary>
+        private ProjectGraphNode? FindDeepestProjectContaining(string file)
+        {
+            ProjectGraphNode? deepest = null;
+            var deepestLength = -1;
+
+            foreach (var node in _graph.ProjectNodes)
+            {
+                var directory = node.ProjectInstance.Directory;
+                if (string.IsNullOrEmpty(directory))
+                    continue;
+
+                var prefix = directory.EndsWith(Path.DirectorySeparatorChar)
+                    ? directory
+                    : directory + Path.DirectorySeparatorChar;
+
+                if (!file.StartsWith(prefix, PathComparison))
+                    continue;
+
+                if (prefix.Length > deepestLength)
+                {
+                    deepestLength = prefix.Length;
+                    deepest = node;
+                }
+            }
+
+            return deepest;
         }
     }
 }

--- a/test/DotnetAffected.Core.Tests/GitChangeDetectionTests.cs
+++ b/test/DotnetAffected.Core.Tests/GitChangeDetectionTests.cs
@@ -48,5 +48,77 @@ namespace DotnetAffected.Core.Tests
             Assert.Equal(projectName, projectInfo.GetProjectName());
             Assert.Equal(msBuildProject.FullPath, projectInfo.GetFullPath());
         }
+
+        /// <summary>
+        /// Regression test for https://github.com/leonardochaia/dotnet-affected/issues/84
+        /// Deleted files no longer exist on disk, so they are not an input of any project
+        /// in the current graph. The owning project must still be reported as changed,
+        /// otherwise its build/test is silently skipped.
+        /// </summary>
+        [Fact]
+        public async Task When_file_inside_project_directory_is_deleted_project_should_have_changes()
+        {
+            // Create a project with a source file, and commit both so that
+            // the deletion is the only pending change.
+            var projectName = "InventoryManagement";
+            var msBuildProject = Repository.CreateCsProject(projectName);
+
+            var targetFilePath = Path.Combine(projectName, "file.cs");
+            await this.Repository.CreateTextFileAsync(targetFilePath, "// Initial content");
+
+            this.Repository.StageAndCommit();
+
+            this.Repository.DeleteFile(targetFilePath);
+
+            Assert.Single(AffectedSummary.FilesThatChanged);
+
+            var projectInfo = Assert.Single(AffectedSummary.ProjectsWithChangedFiles);
+            Assert.Equal(projectName, projectInfo.GetProjectName());
+            Assert.Equal(msBuildProject.FullPath, projectInfo.GetFullPath());
+        }
+
+        /// <summary>
+        /// The containment fallback for deleted files must reach files nested any number
+        /// of directories below the project, not just its immediate children.
+        /// </summary>
+        [Fact]
+        public async Task When_nested_file_inside_project_directory_is_deleted_project_should_have_changes()
+        {
+            var projectName = "InventoryManagement";
+            var msBuildProject = Repository.CreateCsProject(projectName);
+
+            var targetFilePath = Path.Combine(projectName, "Services", "Nested", "OrderService.cs");
+            await this.Repository.CreateTextFileAsync(targetFilePath, "// Initial content");
+
+            this.Repository.StageAndCommit();
+
+            this.Repository.DeleteFile(targetFilePath);
+
+            Assert.Single(AffectedSummary.FilesThatChanged);
+
+            var projectInfo = Assert.Single(AffectedSummary.ProjectsWithChangedFiles);
+            Assert.Equal(projectName, projectInfo.GetProjectName());
+            Assert.Equal(msBuildProject.FullPath, projectInfo.GetFullPath());
+        }
+
+        /// <summary>
+        /// The containment fallback must not over-attribute: deleting a file that lives
+        /// outside every project directory should not mark any project as changed.
+        /// </summary>
+        [Fact]
+        public async Task When_file_outside_any_project_directory_is_deleted_no_project_should_have_changes()
+        {
+            Repository.CreateCsProject("InventoryManagement");
+
+            await this.Repository.CreateTextFileAsync("README.md", "# Initial content");
+
+            this.Repository.StageAndCommit();
+
+            this.Repository.DeleteFile("README.md");
+
+            Assert.Single(AffectedSummary.FilesThatChanged);
+            Assert.Empty(AffectedSummary.ProjectsWithChangedFiles);
+            Assert.Empty(AffectedSummary.AffectedProjects);
+        }
     }
 }

--- a/test/DotnetAffected.Testing.Utils/Repository/TemporaryRepositoryExtensions.cs
+++ b/test/DotnetAffected.Testing.Utils/Repository/TemporaryRepositoryExtensions.cs
@@ -202,21 +202,24 @@ namespace DotnetAffected.Testing.Utils
             string contents)
         {
             path = Path.Combine(repo.Path, path);
-            var file = File.CreateText(path);
-            await file.DisposeAsync();
+
+            // Ensure the containing directory exists so that nested files can be created.
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
             await File.WriteAllTextAsync(path, contents);
         }
 
-        public static async Task CreateTextFileAsync(
+        public static Task CreateTextFileAsync(
             this TemporaryRepository repo,
             ProjectRootElement project,
             string path,
             string contents)
         {
-            path = Path.Combine(repo.Path, project.GetName(), path);
-            var file = File.CreateText(path);
-            await file.DisposeAsync();
-            await File.WriteAllTextAsync(path, contents);
+            return repo.CreateTextFileAsync(Path.Combine(project.GetName(), path), contents);
         }
 
         /// <summary>


### PR DESCRIPTION
When no project claims a changed path *and* the file no longer exists on disk,
fall back to the project whose directory contained it. The deepest containing
directory wins, so files under nested projects attribute to the innermost one.

This is a naive fix, and it was the original algorithm that we used to do before we introduced Predictions.
We could do better, but this catches 90%+ of cases.
Deleting any file under a project directory now marks that project as changed,
**including files that were never build inputs**

Doing better has performance costs, since we would need to create two MSBuild ProjectGraph and compare them. I am analyzing other options as well, but wanted to introduce this to fix the most common case first: files deleted inside a project.

Files referenced outside the project, i.e `Include=".../../../some.props"` would not be detected. This is where we need Predictions.