### PR TITLE
fix: eager loading msbuild to only attempt to load known files

### DIFF
--- a/src/DotnetAffected.Core/FileSystem/EagerCachingMsBuildGitFileSystem.cs
+++ b/src/DotnetAffected.Core/FileSystem/EagerCachingMsBuildGitFileSystem.cs
@@ -2,6 +2,7 @@
 using Microsoft.Build.Evaluation;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace DotnetAffected.Core.FileSystem
@@ -28,15 +29,43 @@ namespace DotnetAffected.Core.FileSystem
         }
         
         /// <summary>
+        /// Extensions MSBuild uses for projects and imports.
+        ///
+        /// Imports are not required to use one of these, but recognising them by extension keeps
+        /// this off the read path: the git file system does no caching, so deciding by content
+        /// would cost an extra blob read for every file MSBuild probes for.
+        ///
+        /// Imports using a non standard extension are therefore deliberately not eager loaded.
+        /// If that ever needs supporting, an option carrying extra extensions to recognise is a
+        /// better trade than inspecting the contents of everything that gets probed.
+        /// </summary>
+        private static readonly HashSet<string> MsBuildProjectExtensions =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ".props", ".targets", ".proj", ".csproj", ".fsproj", ".vbproj",
+                ".vcxproj", ".projitems", ".shproj", ".tasks", ".overridetasks", ".user",
+            };
+
+        /// <summary>
         /// Use this for File.Exists(path)
         /// </summary>
         public override bool FileExists(string path)
         {
             var result = base.FileExists(path);
-            if (result && !UseFileSystem(path))
-                _onEagerCacheRequired?.Invoke(path);
+            if (result && _onEagerCacheRequired is not null && !UseFileSystem(path) && IsMsBuildProjectFile(path))
+                _onEagerCacheRequired.Invoke(path);
             return result;
         }
+
+        /// <summary>
+        /// MSBuild probes for the existence of plenty of files that are not MSBuild projects:
+        /// <c>global.json</c> while resolving the SDK, or a <c>.slnx</c> reached through
+        /// <c>[MSBuild]::GetDirectoryNameOfFileAbove</c>. Eager loading those as projects throws,
+        /// so only eager load what MSBuild could actually import.
+        /// See https://github.com/leonardochaia/dotnet-affected/issues/155
+        /// </summary>
+        private static bool IsMsBuildProjectFile(string path)
+            => MsBuildProjectExtensions.Contains(Path.GetExtension(path));
 
         public Project CreateProjectAndEagerLoadChildren(string path)
         {

--- a/test/DotnetAffected.Core.Tests/EagerCachingFileSystemTests.cs
+++ b/test/DotnetAffected.Core.Tests/EagerCachingFileSystemTests.cs
@@ -1,0 +1,105 @@
+using DotnetAffected.Testing.Utils;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DotnetAffected.Core.Tests
+{
+    /// <summary>
+    /// Tests for the eager loading file system used when diffing NuGet packages.
+    ///
+    /// Loading a project from a commit goes through
+    /// <see cref="DotnetAffected.Core.FileSystem.EagerCachingMsBuildGitFileSystem"/>, which
+    /// eagerly loads every file MSBuild probes for. MSBuild probes for plenty of files that
+    /// are not MSBuild projects, so the eager loader must not try to parse them.
+    /// </summary>
+    public class EagerCachingFileSystemTests : BaseDotnetAffectedTest
+    {
+        /// <summary>
+        /// Regression test for https://github.com/leonardochaia/dotnet-affected/issues/155
+        ///
+        /// `GetDirectoryNameOfFileAbove` probes each directory above the project for the
+        /// .slnx. The eager loader answers that probe by parsing the .slnx as an MSBuild
+        /// project, which fails with "The element &lt;Solution&gt; is unrecognized".
+        /// </summary>
+        [Fact]
+        public async Task When_directory_build_props_probes_for_a_slnx_packages_should_still_be_diffed()
+        {
+            var projectName = "Lib";
+
+            await Repository.CreateXmlSolutionAsync("repro.slnx", $"{projectName}/{projectName}.csproj");
+
+            await Repository.CreateTextFileAsync("Directory.Build.props", @"
+<Project>
+    <PropertyGroup>
+        <SolutionRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'repro.slnx'))</SolutionRoot>
+    </PropertyGroup>
+</Project>
+");
+
+            var packageName = "Some.Library";
+            Repository.CreateDirectoryPackageProps(
+                b => b.AddPackageVersion(packageName, "1.0.0"));
+
+            var msBuildProject = Repository.CreateCsProject(
+                projectName,
+                b => b.AddNuGetDependency(packageName));
+
+            Repository.StageAndCommit();
+
+            Repository.UpdateDirectoryPackageProps(
+                b => b.UpdatePackageVersion(packageName, "2.0.0"));
+
+            // Must not throw InvalidProjectFileException.
+            Assert.Single(AffectedSummary.ChangedPackages);
+
+            var projectInfo = Assert.Single(AffectedSummary.AffectedProjects);
+            Assert.Equal(msBuildProject.FullPath, projectInfo.GetFullPath());
+        }
+
+        /// <summary>
+        /// Same defect as the .slnx case, but for a file that is not XML at all, which fails
+        /// while parsing rather than on an unexpected root element.
+        ///
+        /// Note that a global.json is normally read while resolving the SDK, which happens
+        /// outside the evaluation file system and so never reaches the eager loader. It only
+        /// gets there when a project explicitly probes for it, as below.
+        /// </summary>
+        [Fact]
+        public async Task When_directory_build_props_probes_for_a_global_json_packages_should_still_be_diffed()
+        {
+            await Repository.CreateTextFileAsync("global.json", @"{
+    ""sdk"": {
+        ""version"": ""10.0.201"",
+        ""rollForward"": ""latestMinor""
+    }
+}");
+
+            await Repository.CreateTextFileAsync("Directory.Build.props", @"
+<Project>
+    <PropertyGroup>
+        <RepoRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'global.json'))</RepoRoot>
+    </PropertyGroup>
+</Project>
+");
+
+            var packageName = "Some.Library";
+            Repository.CreateDirectoryPackageProps(
+                b => b.AddPackageVersion(packageName, "1.0.0"));
+
+            var msBuildProject = Repository.CreateCsProject(
+                "Lib",
+                b => b.AddNuGetDependency(packageName));
+
+            Repository.StageAndCommit();
+
+            Repository.UpdateDirectoryPackageProps(
+                b => b.UpdatePackageVersion(packageName, "2.0.0"));
+
+            Assert.Single(AffectedSummary.ChangedPackages);
+
+            var projectInfo = Assert.Single(AffectedSummary.AffectedProjects);
+            Assert.Equal(msBuildProject.FullPath, projectInfo.GetFullPath());
+        }
+    }
+}


### PR DESCRIPTION
Fixes [#155](https://github.com/leonardochaia/dotnet-affected/issues/155).

Every file MSBuild probed for while evaluating a project from a commit was being parsed as an MSBuild project. MSBuild probes for plenty of things that are not projects, so a Directory.Build.props calling `[MSBuild]::GetDirectoryNameOfFileAbove` to locate a `.slnx` would fail package diffing with "The element <Solution> is unrecognized, or not supported in this context". 

Eager loading is now limited to files whose extension MSBuild actually uses for projects and imports
In the future this could be extended for custom extensions if required.