### PR TITLE
fix(predictions): honor gitignore and explicitely ignore the SDK path

### DIFF
--- a/src/DotnetAffected.Core/FileSystem/MsBuildGitFileSystem.cs
+++ b/src/DotnetAffected.Core/FileSystem/MsBuildGitFileSystem.cs
@@ -25,6 +25,9 @@ namespace DotnetAffected.Core.FileSystem
     {
         private readonly Repository _repository;
         private readonly Commit? _commit;
+        private static readonly string? MsBuildSdkDirectory =
+            Path.GetDirectoryName(typeof(Project).Assembly.Location);
+        private readonly Dictionary<string, bool> _ignoredCache = new Dictionary<string, bool>();
 
         public MsBuildGitFileSystem(Repository repository, Commit? commit)
         {
@@ -48,11 +51,13 @@ namespace DotnetAffected.Core.FileSystem
         /// When a <paramref name="path"/> belongs to the file system it means that we will get file content for this
         /// path from the file system. If not, it belongs to the commit so we will get the content from the commit. <para/>
         /// 
-        /// There are 2 scenarios where a <paramref name="path"/> qualify as belonging to the file system:
+        /// There are 4 scenarios where a <paramref name="path"/> qualify as belonging to the file system:
         ///
         /// <list type="number">
         ///   <item>There is no Commit (commit is null), i.e. this file system is pointing at the working directory. <br/> OR</item>
-        ///   <item>There is a Commit but the <paramref name="path"/> is outside of the boundaries of the repository.</item>
+        ///   <item>There is a Commit but the <paramref name="path"/> is outside of the boundaries of the repository. <br/> OR</item>
+        ///   <item>The <paramref name="path"/> belongs to the SDK MSBuild was loaded from, which may sit inside the working directory. <br/> OR</item>
+        ///   <item>The <paramref name="path"/> is ignored by git, so it is not repository content and no commit describes it.</item>
         /// </list>
         ///
         /// The 2nd scenario states we're in file system representing the commit however, the <paramref name="path"/> might
@@ -67,7 +72,33 @@ namespace DotnetAffected.Core.FileSystem
         /// </summary>
         /// <param name="path"></param>
         protected bool UseFileSystem(string path)
-            => _commit is null || !path.StartsWith(_repository.Info.WorkingDirectory);
+        {
+            if (_commit is null || !path.StartsWith(_repository.Info.WorkingDirectory))
+                return true;
+
+            // This covers the cases where the SDK is installed inside the working directory,
+            // but not gitignored.
+            // See https://github.com/leonardochaia/dotnet-affected/issues/154
+            if (MsBuildSdkDirectory is not null && path.StartsWith(MsBuildSdkDirectory))
+                return true;
+
+            // Ignored paths are not repository content, so the commit says nothing
+            // about them and they must be served from disk.
+            // Untracked but not ignored paths are a different matter: those genuinely did not
+            // exist at the commit, so they must keep resolving to missing.
+            return IsPathIgnored(path);
+        }
+
+        private bool IsPathIgnored(string path)
+        {
+            if (_ignoredCache.TryGetValue(path, out var isIgnored))
+                return isIgnored;
+
+            isIgnored = _repository.Ignore.IsPathIgnored(NormalizePathToGitDir(path));
+            _ignoredCache[path] = isIgnored;
+
+            return isIgnored;
+        }
 
         private Stream GetFileStreamGit(Commit commit, string path)
         {

--- a/test/DotnetAffected.Core.Tests/GitIgnoredPathsDetectionTests.cs
+++ b/test/DotnetAffected.Core.Tests/GitIgnoredPathsDetectionTests.cs
@@ -1,0 +1,71 @@
+using DotnetAffected.Testing.Utils;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DotnetAffected.Core.Tests
+{
+    /// <summary>
+    /// Tests for paths that live inside the working directory but are not repository content.
+    ///
+    /// The git file system decided what belongs to a commit by path prefix alone, so anything
+    /// sitting inside the working directory without being tracked resolved to "missing".
+    /// The SDK is regularly installed there on CI runners, and MSBuild guards its own imports
+    /// with Exists(), so those imports were silently skipped and SDK properties went undefined.
+    /// </summary>
+    public class GitIgnoredPathsDetectionTests : BaseDotnetAffectedTest
+    {
+        /// <summary>
+        /// Regression test for https://github.com/leonardochaia/dotnet-affected/issues/154
+        ///
+        /// Mirrors how the SDK fails without needing a real SDK inside the repository: an
+        /// ignored directory holding a props file, imported under Exists(), whose property is
+        /// then used by a property function that only works when the import actually happened.
+        /// That is exactly the shape of `[MSBuild]::Add($(NETCoreAppMaximumVersion), 1)` in
+        /// Microsoft.NET.SupportedTargetFrameworks.props.
+        /// </summary>
+        [Fact]
+        public async Task When_an_ignored_directory_holds_an_imported_props_packages_should_still_be_diffed()
+        {
+            await Repository.CreateTextFileAsync(".gitignore", "localsdk/\n");
+
+            // Ignored, so it never reaches the commit and can only be served from disk.
+            await Repository.CreateTextFileAsync("localsdk/Versions.props", @"
+<Project>
+    <PropertyGroup>
+        <LocalSdkVersion>10</LocalSdkVersion>
+    </PropertyGroup>
+</Project>
+");
+
+            await Repository.CreateTextFileAsync("Directory.Build.props", @"
+<Project>
+    <Import Project=""$(MSBuildThisFileDirectory)localsdk/Versions.props""
+            Condition=""Exists('$(MSBuildThisFileDirectory)localsdk/Versions.props')"" />
+    <PropertyGroup>
+        <NextLocalSdkVersion>$([MSBuild]::Add($(LocalSdkVersion), 1))</NextLocalSdkVersion>
+    </PropertyGroup>
+</Project>
+");
+
+            var packageName = "Some.Library";
+            Repository.CreateDirectoryPackageProps(
+                b => b.AddPackageVersion(packageName, "1.0.0"));
+
+            var msBuildProject = Repository.CreateCsProject(
+                "Lib",
+                b => b.AddNuGetDependency(packageName));
+
+            Repository.StageAndCommit();
+
+            Repository.UpdateDirectoryPackageProps(
+                b => b.UpdatePackageVersion(packageName, "2.0.0"));
+
+            // Without the import, LocalSdkVersion is empty and [MSBuild]::Add throws
+            // "Method '[MSBuild]::Add' not found" while evaluating the project from the commit.
+            Assert.Single(AffectedSummary.ChangedPackages);
+
+            var projectInfo = Assert.Single(AffectedSummary.AffectedProjects);
+            Assert.Equal(msBuildProject.FullPath, projectInfo.GetFullPath());
+        }
+    }
+}


### PR DESCRIPTION
fixes #154 

The SDK path and git-ignored paths, are now served from disk. This should fix #154.

The actual failure pattern is an ignored directory holding a props file imported under `Exists()`, whose property feeds `[MSBuild]::Add`. With the old behaviour it fails with the identical error. 

I managed to reproduce the issue inside this very same repository doing dependency-bump which is what made the end to end reproduction possible.
