### PR TITLE
fixes: deleted files not predicting affected projects

### DIFF
--- a/src/DotnetAffected.Abstractions/IChangesProvider.cs
+++ b/src/DotnetAffected.Abstractions/IChangesProvider.cs
@@ -38,5 +38,23 @@ namespace DotnetAffected.Abstractions
         /// <returns></returns>
         Project? LoadDirectoryPackagePropsProject(string directory, string pathToFile, string? commitRef,
             bool fallbackToHead);
+
+        /// <summary>
+        /// Reads the contents of <paramref name="filePaths"/> as they were at <paramref name="commitRef"/>.
+        ///
+        /// This is the primitive the <c>LoadProject</c> methods are built on, exposed so that
+        /// files removed by the diff can still be read back after they are gone from disk.
+        /// </summary>
+        /// <param name="directory">Root of the repository.</param>
+        /// <param name="commitRef">Commit to read from. When null or empty, HEAD is used.</param>
+        /// <param name="filePaths">Absolute paths of the files to read.</param>
+        /// <returns>
+        /// Contents keyed by absolute path. Paths that did not exist at
+        /// <paramref name="commitRef"/> are absent from the result.
+        /// </returns>
+        IReadOnlyDictionary<string, byte[]> ReadFilesAt(
+            string directory,
+            string? commitRef,
+            IReadOnlyCollection<string> filePaths);
     }
 }

--- a/src/DotnetAffected.Core/AssumptionChangesProvider.cs
+++ b/src/DotnetAffected.Core/AssumptionChangesProvider.cs
@@ -47,5 +47,12 @@ namespace DotnetAffected.Core
         {
             throw new System.InvalidOperationException("--assume-changes should not try to access file contents");
         }
+
+        /// <inheritdoc />
+        public IReadOnlyDictionary<string, byte[]> ReadFilesAt(string directory, string? commitRef,
+            IReadOnlyCollection<string> filePaths)
+        {
+            throw new System.InvalidOperationException("--assume-changes should not try to access file contents");
+        }
     }
 }

--- a/src/DotnetAffected.Core/FileSystem/DeletedFilesOverlayFileSystem.cs
+++ b/src/DotnetAffected.Core/FileSystem/DeletedFilesOverlayFileSystem.cs
@@ -1,0 +1,233 @@
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.FileSystem;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Enumeration;
+using System.Linq;
+using System.Text;
+using System.Xml;
+
+namespace DotnetAffected.Core.FileSystem
+{
+    /// <summary>
+    /// The working directory as it is on disk, with deleted files put back.
+    ///
+    /// A deleted file is not on disk any more, so it matches no glob and satisfies no
+    /// <c>Exists()</c> condition. The project that referenced it therefore evaluates as if the
+    /// file had never been there, and nothing attributes the deletion back to it.
+    /// See https://github.com/leonardochaia/dotnet-affected/issues/84
+    ///
+    /// Everything except the deleted paths is served straight from disk. That keeps evaluation
+    /// on the real file system, rather than reconstructing the whole tree from a commit.
+    /// </summary>
+    internal class DeletedFilesOverlayFileSystem : MSBuildFileSystemBase
+    {
+        private static readonly StringComparer PathComparer = GitChangesProvider.IsWindows
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+
+        /// <summary>Contents of the files the diff removed, keyed by absolute path.</summary>
+        private readonly IReadOnlyDictionary<string, byte[]> _deletedFiles;
+
+        /// <summary>
+        /// Directories that only exist because a deleted file lived in them. Enumerating a
+        /// parent has to reach them, otherwise a recursive glob stops before the deleted file.
+        /// </summary>
+        private readonly HashSet<string> _deletedDirectories;
+
+        public DeletedFilesOverlayFileSystem(
+            string repositoryRoot,
+            IReadOnlyDictionary<string, byte[]> deletedFiles)
+        {
+            _deletedFiles = deletedFiles;
+            _deletedDirectories = new HashSet<string>(PathComparer);
+
+            var root = Path.TrimEndingDirectorySeparator(Path.GetFullPath(repositoryRoot));
+            foreach (var file in _deletedFiles.Keys)
+            {
+                var directory = Path.GetDirectoryName(file);
+                while (!string.IsNullOrEmpty(directory)
+                       && directory.Length > root.Length
+                       && _deletedDirectories.Add(directory))
+                {
+                    directory = Path.GetDirectoryName(directory);
+                }
+            }
+        }
+
+        private ProjectCollection? _projectCollection;
+        private readonly HashSet<string> _preloaded = new HashSet<string>(PathComparer);
+
+        /// <summary>
+        /// Registers the deleted imports in <paramref name="projectCollection"/> ahead of
+        /// evaluation.
+        ///
+        /// MSBuild resolves an <c>Import</c> by reading it off the real disk rather than through
+        /// the file system it was given (dotnet/msbuild#7956), so a deleted import would fail to
+        /// resolve no matter what this file system reports. Registering it as a
+        /// <see cref="ProjectRootElement"/> first means import resolution finds it in the
+        /// collection's cache and never reaches the disk.
+        /// </summary>
+        public void AttachProjectCollection(ProjectCollection projectCollection)
+        {
+            _projectCollection = projectCollection;
+
+            // Eagerly, not on demand: an unconditional Import never asks whether the file
+            // exists, so waiting for a FileExists call would miss it entirely.
+            foreach (var file in _deletedFiles.Keys)
+                PreloadIfImportable(file);
+        }
+
+        private void PreloadIfImportable(string fullPath)
+        {
+            if (_projectCollection is null)
+                return;
+            if (!MsBuildFileExtensions.IsMsBuildProjectFile(fullPath))
+                return;
+            if (!_preloaded.Add(fullPath))
+                return;
+
+            using var stream = GetDeletedFileStream(fullPath);
+            using var reader = new XmlTextReader(stream);
+
+            var rootElement = ProjectRootElement.Create(reader, _projectCollection);
+            rootElement.FullPath = fullPath;
+        }
+
+        private bool IsDeleted(string path) => _deletedFiles.ContainsKey(Path.GetFullPath(path));
+
+        private Stream GetDeletedFileStream(string path)
+            => new MemoryStream(_deletedFiles[Path.GetFullPath(path)], writable: false);
+
+        /// <summary>
+        /// Deleted entries directly in, or underneath, <paramref name="path"/>.
+        /// </summary>
+        private IEnumerable<string> DeletedEntriesUnder(
+            IEnumerable<string> candidates,
+            string path,
+            string searchPattern,
+            SearchOption searchOption)
+        {
+            var directory = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+            var prefix = directory + Path.DirectorySeparatorChar;
+
+            foreach (var candidate in candidates)
+            {
+                if (!candidate.StartsWith(prefix, StringComparison.Ordinal))
+                    continue;
+
+                if (searchOption == SearchOption.TopDirectoryOnly
+                    && !PathComparer.Equals(Path.GetDirectoryName(candidate), directory))
+                    continue;
+
+                var name = Path.GetFileName(candidate);
+                if (FileSystemName.MatchesWin32Expression(searchPattern.AsSpan(), name, false))
+                    yield return candidate;
+            }
+        }
+
+        private IEnumerable<string> Combine(
+            IEnumerable<string> fromDisk,
+            IEnumerable<string> fromDeleted)
+        {
+            var seen = new HashSet<string>(PathComparer);
+            foreach (var entry in fromDisk)
+            {
+                if (seen.Add(Path.GetFullPath(entry)))
+                    yield return entry;
+            }
+
+            foreach (var entry in fromDeleted)
+            {
+                if (seen.Add(entry))
+                    yield return entry;
+            }
+        }
+
+        public override bool FileExists(string path)
+        {
+            if (File.Exists(path))
+                return true;
+
+            if (!IsDeleted(path))
+                return false;
+
+            // Get the deleted file into the collection's cache before MSBuild tries to import it.
+            PreloadIfImportable(Path.GetFullPath(path));
+            return true;
+        }
+
+        public override bool DirectoryExists(string path)
+            => Directory.Exists(path) || _deletedDirectories.Contains(Path.GetFullPath(path));
+
+        public override bool FileOrDirectoryExists(string path)
+            => FileExists(path) || DirectoryExists(path);
+
+        public override TextReader ReadFile(string path)
+            => IsDeleted(path)
+                ? new StreamReader(GetDeletedFileStream(path), Encoding.UTF8)
+                : new StreamReader(path);
+
+        public override Stream GetFileStream(string path, FileMode mode, FileAccess access, FileShare share)
+        {
+            if (!IsDeleted(path))
+                return File.Open(path, mode, access, share);
+
+            if (mode != FileMode.Open || access != FileAccess.Read)
+                throw new InvalidOperationException(
+                    $"Deleted files are readonly. [FileMode: {mode}, FileAccess: {access}]");
+
+            return GetDeletedFileStream(path);
+        }
+
+        public override string ReadFileAllText(string path)
+        {
+            if (!IsDeleted(path))
+                return File.ReadAllText(path);
+
+            using var reader = ReadFile(path);
+            return reader.ReadToEnd();
+        }
+
+        public override byte[] ReadFileAllBytes(string path)
+            => IsDeleted(path)
+                ? Encoding.UTF8.GetBytes(ReadFileAllText(path))
+                : File.ReadAllBytes(path);
+
+        public override IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*",
+            SearchOption searchOption = SearchOption.TopDirectoryOnly)
+            => Combine(
+                Directory.Exists(path)
+                    ? Directory.EnumerateFiles(path, searchPattern, searchOption)
+                    : Enumerable.Empty<string>(),
+                DeletedEntriesUnder(_deletedFiles.Keys, path, searchPattern, searchOption));
+
+        public override IEnumerable<string> EnumerateDirectories(string path, string searchPattern = "*",
+            SearchOption searchOption = SearchOption.TopDirectoryOnly)
+            => Combine(
+                Directory.Exists(path)
+                    ? Directory.EnumerateDirectories(path, searchPattern, searchOption)
+                    : Enumerable.Empty<string>(),
+                DeletedEntriesUnder(_deletedDirectories, path, searchPattern, searchOption));
+
+        public override IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern = "*",
+            SearchOption searchOption = SearchOption.TopDirectoryOnly)
+            => Combine(
+                Directory.Exists(path)
+                    ? Directory.EnumerateFileSystemEntries(path, searchPattern, searchOption)
+                    : Enumerable.Empty<string>(),
+                DeletedEntriesUnder(_deletedFiles.Keys.Concat(_deletedDirectories), path, searchPattern, searchOption));
+
+        public override FileAttributes GetAttributes(string path)
+            => DirectoryExists(path) ? FileAttributes.Directory : FileAttributes.Normal;
+
+        public override DateTime GetLastWriteTimeUtc(string path)
+            // Deleted files have no meaningful timestamp. Nothing in evaluation depends on it,
+            // and reporting "just now" keeps any up to date check from treating them as stale.
+            => IsDeleted(path)
+                ? DateTime.UtcNow
+                : new FileInfo(path).LastWriteTimeUtc;
+    }
+}

--- a/src/DotnetAffected.Core/FileSystem/EagerCachingMsBuildGitFileSystem.cs
+++ b/src/DotnetAffected.Core/FileSystem/EagerCachingMsBuildGitFileSystem.cs
@@ -29,24 +29,6 @@ namespace DotnetAffected.Core.FileSystem
         }
         
         /// <summary>
-        /// Extensions MSBuild uses for projects and imports.
-        ///
-        /// Imports are not required to use one of these, but recognising them by extension keeps
-        /// this off the read path: the git file system does no caching, so deciding by content
-        /// would cost an extra blob read for every file MSBuild probes for.
-        ///
-        /// Imports using a non standard extension are therefore deliberately not eager loaded.
-        /// If that ever needs supporting, an option carrying extra extensions to recognise is a
-        /// better trade than inspecting the contents of everything that gets probed.
-        /// </summary>
-        private static readonly HashSet<string> MsBuildProjectExtensions =
-            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-            {
-                ".props", ".targets", ".proj", ".csproj", ".fsproj", ".vbproj",
-                ".vcxproj", ".projitems", ".shproj", ".tasks", ".overridetasks", ".user",
-            };
-
-        /// <summary>
         /// Use this for File.Exists(path)
         /// </summary>
         public override bool FileExists(string path)
@@ -65,7 +47,7 @@ namespace DotnetAffected.Core.FileSystem
         /// See https://github.com/leonardochaia/dotnet-affected/issues/155
         /// </summary>
         private static bool IsMsBuildProjectFile(string path)
-            => MsBuildProjectExtensions.Contains(Path.GetExtension(path));
+            => MsBuildFileExtensions.IsMsBuildProjectFile(path);
 
         public Project CreateProjectAndEagerLoadChildren(string path)
         {

--- a/src/DotnetAffected.Core/FileSystem/MsBuildFileExtensions.cs
+++ b/src/DotnetAffected.Core/FileSystem/MsBuildFileExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace DotnetAffected.Core.FileSystem
+{
+    /// <summary>
+    /// Extensions MSBuild uses for projects and imports.
+    ///
+    /// Imports are not required to use one of these, but recognising them by extension keeps
+    /// this off the read path. Imports using a non standard extension are deliberately not
+    /// recognised. If that ever needs supporting, an option carrying extra extensions is a
+    /// better trade than inspecting the contents of every file that gets probed.
+    /// </summary>
+    internal static class MsBuildFileExtensions
+    {
+        private static readonly HashSet<string> Known =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ".props", ".targets", ".proj", ".csproj", ".fsproj", ".vbproj",
+                ".vcxproj", ".projitems", ".shproj", ".tasks", ".overridetasks", ".user",
+            };
+
+        public static bool IsMsBuildProjectFile(string path)
+            => Known.Contains(Path.GetExtension(path));
+    }
+}

--- a/src/DotnetAffected.Core/GitChangesProvider.cs
+++ b/src/DotnetAffected.Core/GitChangesProvider.cs
@@ -2,6 +2,7 @@
 using DotnetAffected.Core.FileSystem;
 using LibGit2Sharp;
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.FileSystem;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -47,6 +48,41 @@ namespace DotnetAffected.Core
         public Project? LoadProject(string directory, string pathToFile, string? commitRef, bool fallbackToHead)
         {
             return LoadProjectCore(directory, pathToFile, commitRef, fallbackToHead);
+        }
+
+        /// <inheritdoc />
+        public IReadOnlyDictionary<string, byte[]> ReadFilesAt(
+            string directory,
+            string? commitRef,
+            IReadOnlyCollection<string> filePaths)
+        {
+            var contents = new Dictionary<string, byte[]>();
+            if (filePaths.Count == 0)
+                return contents;
+
+            using var repository = new Repository(directory);
+
+            var commit = string.IsNullOrWhiteSpace(commitRef)
+                ? repository.Head.Tip
+                : GetCommitOrThrow(repository, commitRef);
+
+            foreach (var path in filePaths)
+            {
+                var relativePath = Path.GetRelativePath(repository.Info.WorkingDirectory, path);
+                if (IsWindows)
+                    relativePath = relativePath.Replace('\\', '/');
+
+                if (commit[relativePath]?.Target is not Blob blob)
+                    continue;
+
+                using var stream = blob.GetContentStream();
+                using var buffer = new MemoryStream();
+                stream.CopyTo(buffer);
+
+                contents[Path.GetFullPath(path)] = buffer.ToArray();
+            }
+
+            return contents;
         }
 
         private Project? LoadProjectCore(string directory, string pathToFile, string? commitRef, bool fallbackToHead)

--- a/src/DotnetAffected.Core/Prediction/PredictionChangedProjectsProvider.cs
+++ b/src/DotnetAffected.Core/Prediction/PredictionChangedProjectsProvider.cs
@@ -2,7 +2,6 @@
 using Microsoft.Build.Graph;
 using Microsoft.Build.Prediction;
 using Microsoft.Build.Prediction.Predictors;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -16,13 +15,6 @@ namespace DotnetAffected.Core
     public class PredictionChangedProjectsProvider : IChangedProjectsProvider
     {
         private readonly ProjectGraph _graph;
-
-        /// <summary>
-        /// File systems on Windows are case insensitive, everywhere else they are not.
-        /// </summary>
-        private static readonly StringComparison PathComparison = GitChangesProvider.IsWindows
-            ? StringComparison.OrdinalIgnoreCase
-            : StringComparison.Ordinal;
 
         private static readonly ProjectFileAndImportsGraphPredictor[] GraphPredictors = new[]
         {
@@ -84,64 +76,16 @@ namespace DotnetAffected.Core
             {
                 // determine nodes depending on the changed file
                 var nodesWithFiles = collector.PredictionsPerNode
-                    .Where(x => x.Value.Contains(file))
-                    .Select(x => x.Key)
-                    .ToList();
+                    .Where(x => x.Value.Contains(file));
 
-                // A deleted file is gone from disk, so it is no longer an input of any
-                // project in the current graph and no predictor can claim it. Fall back
-                // to the project whose directory contained it, otherwise the owning
-                // project is silently left out of the build.
-                // See https://github.com/leonardochaia/dotnet-affected/issues/84
-                if (nodesWithFiles.Count == 0 && !File.Exists(file))
+                foreach (var (key, _) in nodesWithFiles)
                 {
-                    var containingNode = FindDeepestProjectContaining(file);
-                    if (containingNode is not null)
+                    if (hasReturned.Add(key.ProjectInstance.FullPath))
                     {
-                        nodesWithFiles.Add(containingNode);
-                    }
-                }
-
-                foreach (var node in nodesWithFiles)
-                {
-                    if (hasReturned.Add(node.ProjectInstance.FullPath))
-                    {
-                        yield return node;
+                        yield return key;
                     }
                 }
             }
-        }
-
-        /// <summary>
-        /// Finds the project whose directory contains <paramref name="file"/>.
-        /// The deepest directory wins, so nested projects attribute to the innermost one.
-        /// </summary>
-        private ProjectGraphNode? FindDeepestProjectContaining(string file)
-        {
-            ProjectGraphNode? deepest = null;
-            var deepestLength = -1;
-
-            foreach (var node in _graph.ProjectNodes)
-            {
-                var directory = node.ProjectInstance.Directory;
-                if (string.IsNullOrEmpty(directory))
-                    continue;
-
-                var prefix = directory.EndsWith(Path.DirectorySeparatorChar)
-                    ? directory
-                    : directory + Path.DirectorySeparatorChar;
-
-                if (!file.StartsWith(prefix, PathComparison))
-                    continue;
-
-                if (prefix.Length > deepestLength)
-                {
-                    deepestLength = prefix.Length;
-                    deepest = node;
-                }
-            }
-
-            return deepest;
         }
     }
 }

--- a/src/DotnetAffected.Core/Processor/AffectedProcessorContext.cs
+++ b/src/DotnetAffected.Core/Processor/AffectedProcessorContext.cs
@@ -1,8 +1,10 @@
 ﻿using DotnetAffected.Abstractions;
+using DotnetAffected.Core.FileSystem;
 using Microsoft.Build.Graph;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace DotnetAffected.Core.Processor
 {
@@ -32,7 +34,28 @@ namespace DotnetAffected.Core.Processor
         public IChangedProjectsProvider? ChangedProjectsProvider { get; }
 
         /// <inheritdoc cref="ProjectGraph"/>
-        public ProjectGraph Graph => _graph ??= new ProjectGraphFactory(Options).BuildProjectGraph();
+        public ProjectGraph Graph => _graph ??= BuildProjectGraph();
+
+        /// <summary>
+        /// The graph is built lazily, after the changed files are known, so deleted files can be
+        /// put back before evaluation. Without that a deleted file matches no glob and satisfies
+        /// no Exists() condition, and the project referencing it is never marked as changed.
+        /// Projects are evaluated against the real file system whenever nothing was deleted.
+        /// </summary>
+        private ProjectGraph BuildProjectGraph()
+        {
+            var deletedFiles = ChangedFiles
+                .Where(file => !File.Exists(file))
+                .ToArray();
+
+            if (deletedFiles.Length == 0)
+                return new ProjectGraphFactory(Options).BuildProjectGraph();
+
+            var contents = ChangesProvider.ReadFilesAt(RepositoryPath, FromRef, deletedFiles);
+            var fileSystem = new DeletedFilesOverlayFileSystem(RepositoryPath, contents);
+
+            return new ProjectGraphFactory(Options, fileSystem).BuildProjectGraph();
+        }
 
         internal string[] ChangedFiles { get; set; } = Array.Empty<string>();
         internal ProjectGraphNode[] ChangedProjects { get; set; } = Array.Empty<ProjectGraphNode>();

--- a/src/DotnetAffected.Core/ProjectGraphFactory.cs
+++ b/src/DotnetAffected.Core/ProjectGraphFactory.cs
@@ -1,5 +1,11 @@
 ﻿using DotnetAffected.Abstractions;
+using Microsoft.Build.Definition;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Evaluation.Context;
+using Microsoft.Build.FileSystem;
 using Microsoft.Build.Graph;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace DotnetAffected.Core
 {
@@ -9,14 +15,20 @@ namespace DotnetAffected.Core
     public class ProjectGraphFactory
     {
         private readonly IDiscoveryOptions _options;
+        private readonly MSBuildFileSystemBase? _fileSystem;
 
         /// <summary>
         /// Creates an instance of the factory.
         /// </summary>
         /// <param name="options"></param>
-        public ProjectGraphFactory(IDiscoveryOptions options)
+        /// <param name="fileSystem">
+        /// File system to evaluate projects against. When null, projects are evaluated
+        /// against the real file system, which is the usual case.
+        /// </param>
+        public ProjectGraphFactory(IDiscoveryOptions options, MSBuildFileSystemBase? fileSystem = null)
         {
             _options = options;
+            _fileSystem = fileSystem;
         }
 
         /// <summary>
@@ -31,13 +43,44 @@ namespace DotnetAffected.Core
 
             WriteLine($"Building Dependency Graph");
 
-            var output = new ProjectGraph(allProjects);
+            var output = _fileSystem is null
+                ? new ProjectGraph(allProjects)
+                : BuildProjectGraphUsingFileSystem(allProjects);
 
             WriteLine(
                 $"Built Graph with {output.ConstructionMetrics.NodeCount} Projects " +
                 $"in {output.ConstructionMetrics.ConstructionTime:s\\.ff}s");
 
             return output;
+        }
+
+        /// <summary>
+        /// Evaluates every project in the graph against <see cref="_fileSystem"/>, by way of a
+        /// shared <see cref="EvaluationContext"/>. Sharing matters: imports and globs are
+        /// resolved through the context, so each project has to be evaluated with the same one.
+        /// </summary>
+        private ProjectGraph BuildProjectGraphUsingFileSystem(IEnumerable<string> allProjects)
+        {
+            var projectCollection = new ProjectCollection();
+            var evaluationContext = EvaluationContext.Create(
+                EvaluationContext.SharingPolicy.Shared,
+                _fileSystem);
+
+            if (_fileSystem is FileSystem.DeletedFilesOverlayFileSystem overlay)
+                overlay.AttachProjectCollection(projectCollection);
+
+            return new ProjectGraph(
+                allProjects.Select(project => new ProjectGraphEntryPoint(project)),
+                projectCollection,
+                (projectPath, globalProperties, collection) => Project
+                    .FromFile(projectPath, new ProjectOptions
+                    {
+                        GlobalProperties = globalProperties,
+                        ProjectCollection = collection,
+                        EvaluationContext = evaluationContext,
+                        LoadSettings = ProjectLoadSettings.Default,
+                    })
+                    .CreateProjectInstance());
         }
 
         private void WriteLine(string? message = null)

--- a/test/DotnetAffected.Core.Tests/DeletedFilesOutsideProjectDirectoryTests.cs
+++ b/test/DotnetAffected.Core.Tests/DeletedFilesOutsideProjectDirectoryTests.cs
@@ -1,0 +1,153 @@
+using DotnetAffected.Testing.Utils;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DotnetAffected.Core.Tests
+{
+    /// <summary>
+    /// Deleted files that a project references from outside its own directory.
+    ///
+    /// #157 attributes a deleted file to the project whose directory contained it, which cannot
+    /// help here. The overlay file system closes most of the remainder by putting deleted files
+    /// back for evaluation, so globs match and items resolve as they did before the deletion.
+    /// See https://github.com/leonardochaia/dotnet-affected/issues/84
+    ///
+    /// Each case creates a file under Shared/ referenced by a project in a sibling directory,
+    /// commits, deletes only that file, and asserts the project is reported as changed.
+    /// </summary>
+    public class DeletedFilesOutsideProjectDirectoryTests : BaseDotnetAffectedTest
+    {
+        private const string ProjectName = "InventoryManagement";
+
+        /// <summary>Control: the case #157 fixed. Expected to pass.</summary>
+        [Fact]
+        public async Task Case1_deleted_file_inside_project_directory()
+        {
+            var project = Repository.CreateCsProject(ProjectName);
+            var file = Path.Combine(ProjectName, "file.cs");
+            await Repository.CreateTextFileAsync(file, "// content");
+            Repository.StageAndCommit();
+
+            Repository.DeleteFile(file);
+
+            AssertProjectChanged(project.FullPath);
+        }
+
+        /// <summary>
+        /// Explicit Include of a path outside the project directory. An explicitly included item
+        /// should survive deletion in the evaluated item list, so predictions may still claim it.
+        /// </summary>
+        [Fact]
+        public async Task Case2_deleted_file_outside_project_directory_explicit_include()
+        {
+            var project = Repository.CreateCsProject(
+                ProjectName,
+                p => p.AddItem("Compile", "../Shared/Explicit.cs"));
+
+            await Repository.CreateTextFileAsync(Path.Combine("Shared", "Explicit.cs"), "// content");
+            Repository.StageAndCommit();
+
+            Repository.DeleteFile(Path.Combine("Shared", "Explicit.cs"));
+
+            AssertProjectChanged(project.FullPath);
+        }
+
+        /// <summary>
+        /// Glob Include reaching outside the project directory. A deleted file cannot match a
+        /// glob, and containment cannot reach it either.
+        /// </summary>
+        [Fact]
+        public async Task Case3_deleted_file_outside_project_directory_via_glob()
+        {
+            var project = Repository.CreateCsProject(
+                ProjectName,
+                p => p.AddItem("Compile", @"../Shared/**/*.cs"));
+
+            await Repository.CreateTextFileAsync(Path.Combine("Shared", "Globbed.cs"), "// content");
+            Repository.StageAndCommit();
+
+            Repository.DeleteFile(Path.Combine("Shared", "Globbed.cs"));
+
+            AssertProjectChanged(project.FullPath);
+        }
+
+        /// <summary>
+        /// Unconditional Import of a props outside the project directory.
+        ///
+        /// Without the deleted import registered up front, MSBuild cannot evaluate the project
+        /// at all and graph construction throws. Nothing asks whether the file exists here, so
+        /// the registration has to happen eagerly rather than on a FileExists call.
+        /// </summary>
+        [Fact]
+        public async Task Case4_deleted_props_imported_unconditionally()
+        {
+            await Repository.CreateTextFileAsync(Path.Combine("Shared", "Common.props"),
+                "<Project><PropertyGroup><FromShared>yes</FromShared></PropertyGroup></Project>");
+
+            var project = Repository.CreateCsProject(
+                ProjectName,
+                p => p.AddImport("../Shared/Common.props"));
+
+            Repository.StageAndCommit();
+
+            Repository.DeleteFile(Path.Combine("Shared", "Common.props"));
+
+            AssertProjectChanged(project.FullPath);
+        }
+
+        /// <summary>
+        /// Import guarded by Exists(). Without the overlay MSBuild skips it silently once the
+        /// file is gone, so nothing in the evaluated project records that it ever existed and
+        /// the project is never marked as changed.
+        /// </summary>
+        [Fact]
+        public async Task Case5_deleted_props_imported_conditionally()
+        {
+            await Repository.CreateTextFileAsync(Path.Combine("Shared", "Optional.props"),
+                "<Project><PropertyGroup><FromShared>yes</FromShared></PropertyGroup></Project>");
+
+            var project = Repository.CreateCsProject(
+                ProjectName,
+                p =>
+                {
+                    var import = p.AddImport("../Shared/Optional.props");
+                    import.Condition = "Exists('../Shared/Optional.props')";
+                });
+
+            Repository.StageAndCommit();
+
+            Repository.DeleteFile(Path.Combine("Shared", "Optional.props"));
+
+            AssertProjectChanged(project.FullPath);
+        }
+
+        /// <summary>Linked content file outside the project directory.</summary>
+        [Fact]
+        public async Task Case6_deleted_linked_content_outside_project_directory()
+        {
+            var project = Repository.CreateCsProject(
+                ProjectName,
+                p =>
+                {
+                    var item = p.AddItem("None", "../Shared/data.json");
+                    item.AddMetadata("Link", "data.json");
+                });
+
+            await Repository.CreateTextFileAsync(Path.Combine("Shared", "data.json"), "{}");
+            Repository.StageAndCommit();
+
+            Repository.DeleteFile(Path.Combine("Shared", "data.json"));
+
+            AssertProjectChanged(project.FullPath);
+        }
+
+        private void AssertProjectChanged(string expectedProjectPath)
+        {
+            Assert.Single(AffectedSummary.FilesThatChanged);
+
+            var projectInfo = Assert.Single(AffectedSummary.ProjectsWithChangedFiles);
+            Assert.Equal(expectedProjectPath, projectInfo.GetFullPath());
+        }
+    }
+}

--- a/test/DotnetAffected.Core.Tests/NonSdkProjectDeletedFileTests.cs
+++ b/test/DotnetAffected.Core.Tests/NonSdkProjectDeletedFileTests.cs
@@ -1,0 +1,62 @@
+using DotnetAffected.Testing.Utils;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DotnetAffected.Core.Tests
+{
+    /// <summary>
+    /// Deleted files in projects that have no default globs.
+    ///
+    /// SDK style projects glob their whole directory, so almost any deleted file is still an
+    /// item and gets attributed. Non SDK projects declare their inputs one by one, which makes
+    /// them the clearest way to pin down what attribution does and does not cover.
+    /// </summary>
+    public class NonSdkProjectDeletedFileTests : BaseDotnetAffectedTest
+    {
+        private const string ProjectName = "LegacyInventory";
+
+        /// <summary>
+        /// A declared item keeps its place in the evaluated list whether or not the file is on
+        /// disk, so the project is attributed the deletion.
+        /// </summary>
+        [Fact]
+        public async Task When_a_declared_file_is_deleted_project_should_have_changes()
+        {
+            var project = Repository.CreateNonSdkMsBuildProject(ProjectName, ".csproj");
+
+            await Repository.CreateTextFileAsync(Path.Combine(ProjectName, "file.cs"), "// content");
+            Repository.StageAndCommit();
+
+            Repository.DeleteFile(Path.Combine(ProjectName, "file.cs"));
+
+            Assert.Single(AffectedSummary.FilesThatChanged);
+
+            var projectInfo = Assert.Single(AffectedSummary.ProjectsWithChangedFiles);
+            Assert.Equal(project.FullPath, projectInfo.GetFullPath());
+        }
+
+        /// <summary>
+        /// A file no item ever referenced is not a build input, so deleting it cannot change
+        /// what the project produces and the project is deliberately left alone.
+        ///
+        /// Attribution follows what the project declares. Merely sitting in the project's
+        /// directory does not make a file an input, so nothing is inferred from its location.
+        /// </summary>
+        [Fact]
+        public async Task When_an_undeclared_file_is_deleted_project_should_not_have_changes()
+        {
+            Repository.CreateNonSdkMsBuildProject(ProjectName, ".csproj");
+
+            await Repository.CreateTextFileAsync(Path.Combine(ProjectName, "file.cs"), "// content");
+            await Repository.CreateTextFileAsync(Path.Combine(ProjectName, "notes.txt"), "notes");
+            Repository.StageAndCommit();
+
+            Repository.DeleteFile(Path.Combine(ProjectName, "notes.txt"));
+
+            Assert.Single(AffectedSummary.FilesThatChanged);
+            Assert.Empty(AffectedSummary.ProjectsWithChangedFiles);
+            Assert.Empty(AffectedSummary.AffectedProjects);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #84.

`DeletedFilesOverlayFileSystem` serves the working directory as it is on disk plus the paths the diff removed, read back from the from-commit, so globs match again and `Exists()` conditions hold. Attribution then falls out of the normal prediction machinery. The overlay is only built when the diff actually contains deletions, so every other run evaluates against the real file system exactly as before.

Imports need one extra step. MSBuild resolves an `Import` by reading it off the real disk rather than through the file system it was given (dotnet/msbuild#7956), so a deleted import fails to resolve no matter what the overlay reports. Registering it as a `ProjectRootElement` in the graph's `ProjectCollection` first means import resolution finds it cached and never reaches the disk. That has to happen eagerly rather than on a `FileExists` call, because an unconditional `Import` never asks whether the file exists.

The containment heuristic from #157 is removed. The overlay covers everything it did, and does so through what a project declares rather than what happens to sit in its directory. One behaviour change falls out: deleting a file that no item ever referenced no longer marks the project as changed. It was never a build input, so it cannot change what the project produces. `NonSdkProjectDeletedFileTests` pins both sides of that, since non SDK projects are where the distinction is visible at all.

This adds a breaking change to the `IChangesProvider`. It gains `ReadFilesAt`. Implementations outside this repo need to add it. I am assuming there are no implementations outside this repo...?

Tests cover the six ways a project can reference a file outside its own directory: inside the directory, explicit `Include`, glob, linked content, conditional import, unconditional import.

Credits to @dotTrench for the implementation idea!
