### PR TITLE
Perf/graph traversal and prediction

### DIFF
--- a/benchmarks/dotnet-affected.Benchmarks/AffectedBenchmark.cs
+++ b/benchmarks/dotnet-affected.Benchmarks/AffectedBenchmark.cs
@@ -43,10 +43,11 @@ namespace Affected.Cli.Benchmarks
 
             // Add random files to the tree so that some projects have changes
             var graph = new ProjectGraph(rootNodes.Select(x => x.FullPath));
-            await Repository.MakeChangesInProjectTree(graph);
+            var changedFiles = await Repository.MakeChangesInProjectTree(graph);
 
             Console.WriteLine($"Built graph with total of {graph.ProjectNodes.Count()} " +
-                              $"projects in {graph.ConstructionMetrics.ConstructionTime}");
+                              $"projects in {graph.ConstructionMetrics.ConstructionTime}, " +
+                              $"{changedFiles} files changed");
 
             // Create an executor for the repository using the existing graph.
             Executor = new AffectedExecutor(Repository.Path, graph);

--- a/benchmarks/dotnet-affected.Benchmarks/MacroBenchmarks.cs
+++ b/benchmarks/dotnet-affected.Benchmarks/MacroBenchmarks.cs
@@ -42,10 +42,11 @@ namespace Affected.Cli.Benchmarks
 
             // Add random files to the tree so that some projects have changes
             var graph = new ProjectGraph(rootNodes.Select(x => x.FullPath));
-            await Repository.MakeChangesInProjectTree(graph);
+            var changedFiles = await Repository.MakeChangesInProjectTree(graph);
 
             Console.WriteLine($"Built graph with total of {graph.ProjectNodes.Count()} " +
-                              $"projects in {graph.ConstructionMetrics.ConstructionTime}");
+                              $"projects in {graph.ConstructionMetrics.ConstructionTime}, " +
+                              $"{changedFiles} files changed");
         }
 
         [GlobalCleanup]

--- a/benchmarks/dotnet-affected.Benchmarks/PhaseProfiler.cs
+++ b/benchmarks/dotnet-affected.Benchmarks/PhaseProfiler.cs
@@ -129,9 +129,11 @@ namespace Affected.Cli.Benchmarks
                     .GetChangedFiles(repository.Path, string.Empty, string.Empty)
                     .ToArray());
 
-            // Prediction alone, discarding everything it produces, to separate the cost of
-            // running the predictors from the cost of storing and searching their output.
-            Measure("msbuild prediction only", () =>
+            // Every predictor MSBuild.Prediction ships, discarding the results. This is not the
+            // set the tool actually uses, it is here to show what prediction costs in total and
+            // what dropping a predictor is worth. Compare against the attribute lines below,
+            // which run the real configuration.
+            Measure("prediction, all predictors", () =>
             {
                 var executor = new ProjectGraphPredictionExecutor(
                     ProjectPredictors.AllProjectGraphPredictors,

--- a/benchmarks/dotnet-affected.Benchmarks/PhaseProfiler.cs
+++ b/benchmarks/dotnet-affected.Benchmarks/PhaseProfiler.cs
@@ -27,6 +27,80 @@ namespace Affected.Cli.Benchmarks
             }
         }
 
+        /// <summary>
+        /// Times every predictor on its own over the same graph.
+        ///
+        /// The collector discards outputs, so any predictor that only produces them is pure
+        /// cost. This says which ones are worth dropping before anything is changed.
+        /// </summary>
+        public static async Task RunPredictorBreakdownAsync(int totalProjects, int childrenPerProject)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"=== predictor breakdown: {totalProjects} projects, " +
+                              $"{childrenPerProject} children each ===");
+
+            using var repository = new TemporaryRepository();
+
+            var rootNodes = repository.CreateCsProjTree(totalProjects, childrenPerProject).ToList();
+            repository.StageAndCommit();
+
+            var seedGraph = new ProjectGraph(rootNodes.Select(x => x.FullPath));
+            await repository.MakeChangesInProjectTree(seedGraph);
+
+            var options = new AffectedOptions(repository.Path);
+            var graph = Measure("build project graph",
+                () => new ProjectGraphFactory(options).BuildProjectGraph());
+
+            Console.WriteLine($"graph nodes : {graph.ProjectNodes.Count()}");
+            Console.WriteLine();
+
+            // Cost of walking the graph with nothing to run, so each predictor below can be
+            // read as its own cost rather than cost plus harness.
+            var baseline = TimePredictors("(no predictors: harness only)",
+                graph, Array.Empty<IProjectPredictor>(), Array.Empty<IProjectGraphPredictor>());
+
+            Console.WriteLine();
+            Console.WriteLine($"{"predictor",-52} {"time",8} {"inputs",14}");
+
+            foreach (var predictor in ProjectPredictors.AllProjectPredictors.OrderBy(p => p.GetType().Name))
+            {
+                TimePredictors(predictor.GetType().Name, graph,
+                    new[] { predictor }, Array.Empty<IProjectGraphPredictor>(), baseline);
+            }
+
+            foreach (var predictor in ProjectPredictors.AllProjectGraphPredictors.OrderBy(p => p.GetType().Name))
+            {
+                TimePredictors($"[graph] {predictor.GetType().Name}", graph,
+                    Array.Empty<IProjectPredictor>(), new[] { predictor }, baseline);
+            }
+        }
+
+        private static TimeSpan TimePredictors(
+            string label,
+            ProjectGraph graph,
+            IProjectPredictor[] projectPredictors,
+            IProjectGraphPredictor[] graphPredictors,
+            TimeSpan baseline = default)
+        {
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+            GC.WaitForPendingFinalizers();
+
+            var sink = new CountingCollector();
+            var executor = new ProjectGraphPredictionExecutor(graphPredictors, projectPredictors);
+
+            var watch = Stopwatch.StartNew();
+            executor.PredictInputsAndOutputs(graph, sink);
+            watch.Stop();
+
+            var net = watch.Elapsed - baseline;
+            if (net < TimeSpan.Zero)
+                net = TimeSpan.Zero;
+
+            Console.WriteLine($"{label,-52} {net.TotalSeconds,7:F2}s {sink.Count,14:N0}");
+
+            return watch.Elapsed;
+        }
+
         private static async Task ProfileAsync(int totalProjects, int childrenPerProject)
         {
             Console.WriteLine();
@@ -67,7 +141,14 @@ namespace Affected.Cli.Benchmarks
                 return sink.Count;
             });
 
-            var changedProjects = Measure("attribute files to projects",
+            // Same call with one file and with all of them. Both pay for prediction, so the
+            // difference is what attributing the extra files actually costs.
+            Measure("attribute 1 file",
+                () => new PredictionChangedProjectsProvider(graph, options)
+                    .GetReferencingProjects(changedFiles.Take(1))
+                    .ToArray());
+
+            var changedProjects = Measure($"attribute {changedFiles.Length} files",
                 () => new PredictionChangedProjectsProvider(graph, options)
                     .GetReferencingProjects(changedFiles)
                     .ToArray());

--- a/benchmarks/dotnet-affected.Benchmarks/PhaseProfiler.cs
+++ b/benchmarks/dotnet-affected.Benchmarks/PhaseProfiler.cs
@@ -1,0 +1,128 @@
+using DotnetAffected.Core;
+using DotnetAffected.Testing.Utils;
+using Microsoft.Build.Graph;
+using Microsoft.Build.Prediction;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Affected.Cli.Benchmarks
+{
+    /// <summary>
+    /// Times each phase of a run separately, so a slow run can be attributed to a phase rather
+    /// than guessed at. BenchmarkDotNet measures the whole algorithm as one number, which cannot
+    /// tell prediction apart from attribution or from the affected traversal.
+    ///
+    /// Run with: dotnet run -c Release -f net10.0 -- profile [projectCounts...]
+    /// </summary>
+    public static class PhaseProfiler
+    {
+        public static async Task RunAsync(int[] projectCounts, int childrenPerProject)
+        {
+            foreach (var totalProjects in projectCounts)
+            {
+                await ProfileAsync(totalProjects, childrenPerProject);
+            }
+        }
+
+        private static async Task ProfileAsync(int totalProjects, int childrenPerProject)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"=== {totalProjects} projects, {childrenPerProject} children each ===");
+
+            using var repository = new TemporaryRepository();
+
+            var rootNodes = repository.CreateCsProjTree(totalProjects, childrenPerProject).ToList();
+            repository.StageAndCommit();
+
+            var seedGraph = new ProjectGraph(rootNodes.Select(x => x.FullPath));
+            var changedFileCount = await repository.MakeChangesInProjectTree(seedGraph);
+
+            Console.WriteLine($"graph nodes : {seedGraph.ProjectNodes.Count()} " +
+                              $"(from {totalProjects} project files)");
+            Console.WriteLine($"changed     : {changedFileCount} files");
+            Console.WriteLine();
+
+            var options = new AffectedOptions(repository.Path);
+
+            var graph = Measure("build project graph",
+                () => new ProjectGraphFactory(options).BuildProjectGraph());
+
+            var changedFiles = Measure("git diff (changed files)",
+                () => new GitChangesProvider()
+                    .GetChangedFiles(repository.Path, string.Empty, string.Empty)
+                    .ToArray());
+
+            // Prediction alone, discarding everything it produces, to separate the cost of
+            // running the predictors from the cost of storing and searching their output.
+            Measure("msbuild prediction only", () =>
+            {
+                var executor = new ProjectGraphPredictionExecutor(
+                    ProjectPredictors.AllProjectGraphPredictors,
+                    ProjectPredictors.AllProjectPredictors);
+                var sink = new CountingCollector();
+                executor.PredictInputsAndOutputs(graph, sink);
+                return sink.Count;
+            });
+
+            var changedProjects = Measure("attribute files to projects",
+                () => new PredictionChangedProjectsProvider(graph, options)
+                    .GetReferencingProjects(changedFiles)
+                    .ToArray());
+
+            Measure("find affected (traversal)",
+                () => changedProjects.FindReferencingProjects().ToArray());
+        }
+
+        private static T Measure<T>(string label, Func<T> action)
+        {
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+            GC.WaitForPendingFinalizers();
+
+            var before = GC.GetTotalAllocatedBytes(precise: true);
+            var watch = Stopwatch.StartNew();
+
+            var result = action();
+
+            watch.Stop();
+            var allocated = GC.GetTotalAllocatedBytes(precise: true) - before;
+
+            var count = result is System.Collections.ICollection collection
+                ? collection.Count.ToString()
+                : result?.ToString() ?? "";
+
+            Console.WriteLine($"{label,-28} {watch.Elapsed.TotalSeconds,8:F2}s " +
+                              $"{allocated / 1024d / 1024d,9:F0} MB   {count}");
+
+            return result;
+        }
+
+        /// <summary>Counts predicted inputs without keeping any of them.</summary>
+        private sealed class CountingCollector : IProjectPredictionCollector
+        {
+            private int _count;
+
+            public int Count => _count;
+
+            public void AddInputFile(string path, Microsoft.Build.Execution.ProjectInstance projectInstance,
+                string predictorName) => _count++;
+
+            public void AddInputDirectory(string path, Microsoft.Build.Execution.ProjectInstance projectInstance,
+                string predictorName)
+            {
+            }
+
+            public void AddOutputFile(string path, Microsoft.Build.Execution.ProjectInstance projectInstance,
+                string predictorName)
+            {
+            }
+
+            public void AddOutputDirectory(string path, Microsoft.Build.Execution.ProjectInstance projectInstance,
+                string predictorName)
+            {
+            }
+        }
+    }
+}

--- a/benchmarks/dotnet-affected.Benchmarks/PhaseProfiler.cs
+++ b/benchmarks/dotnet-affected.Benchmarks/PhaseProfiler.cs
@@ -1,5 +1,9 @@
 using DotnetAffected.Core;
 using DotnetAffected.Testing.Utils;
+using Microsoft.Build.Definition;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Evaluation.Context;
+using Microsoft.Build.Execution;
 using Microsoft.Build.Graph;
 using Microsoft.Build.Prediction;
 using System;
@@ -100,6 +104,63 @@ namespace Affected.Cli.Benchmarks
 
             return watch.Elapsed;
         }
+
+        /// <summary>
+        /// Builds the same graph several ways. Graph construction dominates a run, so it is
+        /// worth knowing whether the way we ask for it costs anything.
+        /// </summary>
+        public static async Task RunGraphVariantsAsync(int totalProjects, int childrenPerProject)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"=== graph construction variants: {totalProjects} projects ===");
+
+            using var repository = new TemporaryRepository();
+            var rootNodes = repository.CreateCsProjTree(totalProjects, childrenPerProject).ToList();
+            repository.StageAndCommit();
+
+            var seedGraph = new ProjectGraph(rootNodes.Select(x => x.FullPath));
+            await repository.MakeChangesInProjectTree(seedGraph);
+
+            var projectFiles = rootNodes.Select(x => x.FullPath).ToArray();
+            var entryPoints = projectFiles.Select(p => new ProjectGraphEntryPoint(p)).ToArray();
+
+            Console.WriteLine($"project files: {projectFiles.Length}");
+            Console.WriteLine();
+
+            Measure("1. default (as shipped)",
+                () => new ProjectGraph(projectFiles));
+
+            Measure("2. read only ProjectCollection", () =>
+            {
+                var collection = NewCollection(loadProjectsReadOnly: true);
+                return new ProjectGraph(entryPoints, collection, null);
+            });
+
+            Measure("3. read only + immutable instances", () =>
+            {
+                var collection = NewCollection(loadProjectsReadOnly: true);
+                var context = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
+
+                return new ProjectGraph(entryPoints, collection,
+                    (path, globalProperties, coll) => Project
+                        .FromFile(path, new ProjectOptions
+                        {
+                            GlobalProperties = globalProperties,
+                            ProjectCollection = coll,
+                            EvaluationContext = context,
+                        })
+                        .CreateProjectInstance(ProjectInstanceSettings.Immutable, context));
+            });
+        }
+
+        private static ProjectCollection NewCollection(bool loadProjectsReadOnly) => new ProjectCollection(
+            globalProperties: null,
+            loggers: null,
+            remoteLoggers: null,
+            toolsetDefinitionLocations: ToolsetDefinitionLocations.Default,
+            maxNodeCount: 1,
+            onlyLogCriticalEvents: false,
+            loadProjectsReadOnly: loadProjectsReadOnly);
 
         private static async Task ProfileAsync(int totalProjects, int childrenPerProject)
         {

--- a/benchmarks/dotnet-affected.Benchmarks/Program.cs
+++ b/benchmarks/dotnet-affected.Benchmarks/Program.cs
@@ -17,6 +17,13 @@ namespace Affected.Cli.Benchmarks
             // `profile` runs the phase profiler instead of BenchmarkDotNet. It is a single
             // timed run per size, which is what you want when locating a hotspot rather than
             // measuring a stable number.
+            if (args.Length > 0 && args[0] == "predictors")
+            {
+                var size = args.Length > 1 && int.TryParse(args[1], out var parsed) ? parsed : 1000;
+                await PhaseProfiler.RunPredictorBreakdownAsync(size, childrenPerProject: 20);
+                return;
+            }
+
             if (args.Length > 0 && args[0] == "profile")
             {
                 var sizes = args.Skip(1)

--- a/benchmarks/dotnet-affected.Benchmarks/Program.cs
+++ b/benchmarks/dotnet-affected.Benchmarks/Program.cs
@@ -1,5 +1,7 @@
 using BenchmarkDotNet.Running;
 using Microsoft.Build.Locator;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Affected.Cli.Benchmarks
 {
@@ -10,7 +12,26 @@ namespace Affected.Cli.Benchmarks
             MSBuildLocator.RegisterDefaults();
         }
 
-        static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly)
-            .Run(args);
+        static async Task Main(string[] args)
+        {
+            // `profile` runs the phase profiler instead of BenchmarkDotNet. It is a single
+            // timed run per size, which is what you want when locating a hotspot rather than
+            // measuring a stable number.
+            if (args.Length > 0 && args[0] == "profile")
+            {
+                var sizes = args.Skip(1)
+                    .Select(arg => int.TryParse(arg, out var value) ? value : 0)
+                    .Where(value => value > 0)
+                    .ToArray();
+
+                await PhaseProfiler.RunAsync(
+                    sizes.Length > 0 ? sizes : new[] { 250, 500, 1000 },
+                    childrenPerProject: 20);
+
+                return;
+            }
+
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        }
     }
 }

--- a/benchmarks/dotnet-affected.Benchmarks/Program.cs
+++ b/benchmarks/dotnet-affected.Benchmarks/Program.cs
@@ -17,6 +17,13 @@ namespace Affected.Cli.Benchmarks
             // `profile` runs the phase profiler instead of BenchmarkDotNet. It is a single
             // timed run per size, which is what you want when locating a hotspot rather than
             // measuring a stable number.
+            if (args.Length > 0 && args[0] == "graph")
+            {
+                var graphSize = args.Length > 1 && int.TryParse(args[1], out var gs) ? gs : 500;
+                await PhaseProfiler.RunGraphVariantsAsync(graphSize, childrenPerProject: 20);
+                return;
+            }
+
             if (args.Length > 0 && args[0] == "predictors")
             {
                 var size = args.Length > 1 && int.TryParse(args[1], out var parsed) ? parsed : 1000;

--- a/benchmarks/dotnet-affected.Benchmarks/dotnet-affected.Benchmarks.csproj
+++ b/benchmarks/dotnet-affected.Benchmarks/dotnet-affected.Benchmarks.csproj
@@ -12,7 +12,12 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>
+        <!-- MSBuild is loaded from the installed SDK by MSBuildLocator. Shipping these
+             alongside means the app local copies win and mismatch whatever the SDK has,
+             which fails at runtime as a MissingMethodException. -->
         <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime"/>
+        <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime"/>
+        <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime"/>
         <PackageReference Include="Microsoft.Build.Locator"/>
         <PackageReference Include="System.CodeDom"/>
 

--- a/src/DotnetAffected.Core/Extensions/ProjectGraphNodeExtensions.cs
+++ b/src/DotnetAffected.Core/Extensions/ProjectGraphNodeExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Build.Graph;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -11,8 +10,6 @@ namespace DotnetAffected.Core
     /// </summary>
     public static class ProjectGraphNodeExtensions
     {
-        private static readonly ConcurrentDictionary<string, IEnumerable<ProjectGraphNode>> Cache = new();
-
         /// <summary>
         /// Recursively searches for all <see cref="ProjectGraphNode.ReferencingProjects"/>
         /// in all provided projects.
@@ -21,17 +18,7 @@ namespace DotnetAffected.Core
         /// <returns></returns>
         public static IEnumerable<ProjectGraphNode> FindReferencingProjects(
             this IEnumerable<ProjectGraphNode> targetNodes)
-        {
-            var added = new HashSet<string>();
-            foreach (var node in targetNodes)
-            {
-                foreach (var affected in FindReferencingProjects(node))
-                {
-                    if (added.Add(affected.ProjectInstance.FullPath))
-                        yield return affected;
-                }
-            }
-        }
+            => Traverse(targetNodes);
 
         /// <summary>
         /// Recursively searches for <see cref="ProjectGraphNode.ReferencingProjects"/>
@@ -40,11 +27,48 @@ namespace DotnetAffected.Core
         /// <returns></returns>
         public static IEnumerable<ProjectGraphNode> FindReferencingProjects(
             this ProjectGraphNode targetNode)
+            => Traverse(new[] { targetNode });
+
+        /// <summary>
+        /// Walks the graph backwards from every starting node at once, sharing a single set of
+        /// visited projects, so each project is expanded no more than once.
+        ///
+        /// Computing and keeping a closure per node instead makes the total work the sum of all
+        /// closure sizes, which is quadratic in the size of the graph. Sharing the visited set
+        /// keeps it proportional to the graph itself.
+        /// </summary>
+        private static IEnumerable<ProjectGraphNode> Traverse(IEnumerable<ProjectGraphNode> startingNodes)
         {
-            return Cache.GetOrAdd(
-                targetNode.ProjectInstance.FullPath,
-                _ => FindReferencingProjectsImpl(targetNode)
-                    .ToList());
+            // Keyed by path so that the inner builds of a multi targeted project collapse into
+            // one entry, which is what callers have always been given.
+            var starting = startingNodes as IReadOnlyCollection<ProjectGraphNode> ?? startingNodes.ToList();
+
+            // A multi targeted project appears as an outer node plus one node per framework, all
+            // sharing a path, and the outer node references the inner ones. Seeding the starting
+            // paths keeps a project from being reported as referencing itself.
+            var visited = new HashSet<string>(starting.Select(node => node.ProjectInstance.FullPath));
+            var pending = new Queue<ProjectGraphNode>();
+
+            foreach (var node in starting)
+            {
+                foreach (var referencing in node.ReferencingProjects)
+                {
+                    if (visited.Add(referencing.ProjectInstance.FullPath))
+                        pending.Enqueue(referencing);
+                }
+            }
+
+            while (pending.Count > 0)
+            {
+                var current = pending.Dequeue();
+                yield return current;
+
+                foreach (var referencing in current.ReferencingProjects)
+                {
+                    if (visited.Add(referencing.ProjectInstance.FullPath))
+                        pending.Enqueue(referencing);
+                }
+            }
         }
 
         /// <summary>
@@ -103,22 +127,5 @@ namespace DotnetAffected.Core
             }
         }
 
-        private static IEnumerable<ProjectGraphNode> FindReferencingProjectsImpl(ProjectGraphNode node)
-        {
-            var added = new HashSet<string>();
-            foreach (var referencingProject in node.ReferencingProjects)
-            {
-                // Return all referencing projects
-                if (added.Add(referencingProject.ProjectInstance.FullPath))
-                    yield return referencingProject;
-
-                // Recurse each node's children
-                foreach (var child in FindReferencingProjects(referencingProject))
-                {
-                    if (added.Add(child.ProjectInstance.FullPath))
-                        yield return child;
-                }
-            }
-        }
     }
 }

--- a/src/DotnetAffected.Core/Prediction/PredictionChangedProjectsProvider.cs
+++ b/src/DotnetAffected.Core/Prediction/PredictionChangedProjectsProvider.cs
@@ -2,6 +2,7 @@
 using Microsoft.Build.Graph;
 using Microsoft.Build.Prediction;
 using Microsoft.Build.Prediction.Predictors;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -16,10 +17,21 @@ namespace DotnetAffected.Core
     {
         private readonly ProjectGraph _graph;
 
-        private static readonly ProjectFileAndImportsGraphPredictor[] GraphPredictors = new[]
-        {
-            new ProjectFileAndImportsGraphPredictor()
-        };
+        /// <summary>
+        /// No graph predictors are used.
+        ///
+        /// ProjectFileAndImportsGraphPredictor used to be here. For every project it walks the
+        /// whole transitive dependency closure and reports each dependency's project file and
+        /// imports as an input, so a change to one project marks every project below it as
+        /// changed. That is the relationship <see cref="ProjectGraphNodeExtensions.FindReferencingProjects(ProjectGraphNode)"/>
+        /// already derives from the graph in a single pass, and the output is the union of the
+        /// changed and the affected projects, so the same projects come out either way.
+        ///
+        /// The cost of deriving it twice is not small: on a 4000 node graph it emitted around
+        /// 660 million inputs, which the collector then had to store and search.
+        /// </summary>
+        private static readonly IProjectGraphPredictor[] GraphPredictors =
+            Array.Empty<IProjectGraphPredictor>();
 
         /// <summary>
         /// Keeps a list of all predictors that predict input files.

--- a/test/DotnetAffected.Testing.Utils/Repository/TemporaryRepositoryExtensions.cs
+++ b/test/DotnetAffected.Testing.Utils/Repository/TemporaryRepositoryExtensions.cs
@@ -272,15 +272,20 @@ namespace DotnetAffected.Testing.Utils
         /// <param name="repository"></param>
         /// <param name="graph"></param>
         /// <param name="everyProjectCount"></param>
-        public static async Task MakeChangesInProjectTree(
+        public static async Task<int> MakeChangesInProjectTree(
             this TemporaryRepository repository,
             ProjectGraph graph,
             int everyProjectCount = 5)
         {
             var current = 0;
+            var changed = 0;
+
             foreach (var node in graph.ProjectNodes)
             {
-                if (current % everyProjectCount != 0)
+                // REMARKS: the counter has to advance for every node, not only for the ones we
+                // touch. Advancing it inside the branch left it stuck after the first file, so
+                // this produced a single changed file no matter how large the graph was.
+                if (current++ % everyProjectCount != 0)
                 {
                     continue;
                 }
@@ -289,8 +294,10 @@ namespace DotnetAffected.Testing.Utils
                 var fileContents = $"// contents {current}";
                 await repository.CreateTextFileAsync(filePath, fileContents);
 
-                current++;
+                changed++;
             }
+
+            return changed;
         }
     }
 }


### PR DESCRIPTION
On a 4000 node graph:

| phase | before | after |
|---|---:|---:|
| attribute changed files | 22.38s / 1958MB | 0.52s / 938MB |
| find affected projects | 35.43s / 422MB | 0.07s / 0MB |

Graph construction is unchanged at ~28s and is now around 98% of a run. 


Graph construction is now most of a run, so it is worth recording what does not
help. On a 500 project graph: as shipped 8.95s and 5546MB; with a read only
ProjectCollection 8.99s and 5576MB, which is noise; with immutable project
instances 13.89s and 7816MB, which is worse because reaching them through
Project.FromFile builds the full evaluation model before the instance.

MSBuild already parallelises graph construction across logical cores and its
default factory already constructs ProjectInstance directly against a shared
EvaluationContext, so there is nothing cheaper available through the public API.