### PR TITLE
fix(cli): ensure the CLI always use the overlayed ProjectGraph

### DIFF
--- a/benchmarks/dotnet-affected.Benchmarks/AffectedBenchmark.cs
+++ b/benchmarks/dotnet-affected.Benchmarks/AffectedBenchmark.cs
@@ -49,8 +49,12 @@ namespace Affected.Cli.Benchmarks
                               $"projects in {graph.ConstructionMetrics.ConstructionTime}, " +
                               $"{changedFiles} files changed");
 
-            // Create an executor for the repository using the existing graph.
-            Executor = new AffectedExecutor(Repository.Path, graph);
+            // Keep graph construction out of the measured region by running against the graph
+            // built above. Deleted files are not attributed on this path, which costs this
+            // benchmark nothing: the scenario only adds files.
+            Executor = AffectedExecutor.ForPreEvaluatedGraph(
+                new AffectedOptions(Repository.Path),
+                graph);
         }
 
         public AffectedExecutor Executor { get; set; }

--- a/src/DotnetAffected.Core/AffectedExecutor.cs
+++ b/src/DotnetAffected.Core/AffectedExecutor.cs
@@ -1,4 +1,4 @@
-﻿using DotnetAffected.Abstractions;
+using DotnetAffected.Abstractions;
 using DotnetAffected.Core.Processor;
 using Microsoft.Build.Graph;
 
@@ -12,35 +12,58 @@ namespace DotnetAffected.Core
         private readonly AffectedProcessorContext _context;
 
         /// <summary>
-        /// Creates an executor for a repository path and a graph.
+        /// Creates an executor for a repository path.
         /// </summary>
         /// <param name="repositoryPath"></param>
-        /// <param name="graph"></param>
-        public AffectedExecutor(string repositoryPath, ProjectGraph? graph = null)
-            : this(new AffectedOptions(repositoryPath), graph)
+        public AffectedExecutor(string repositoryPath)
+            : this(new AffectedOptions(repositoryPath))
         {
         }
 
         /// <summary>
-        /// Creates the executor using all parameters.
+        /// Creates the executor.
         /// </summary>
         /// <param name="options"></param>
         /// <param name="changesProvider"></param>
-        /// <param name="graph">
-        /// Leave this null unless you already have a graph you must reuse. When null, the graph is
-        /// built after the changed files are known, so files the diff removed are restored before
-        /// evaluation and stay attributed to their project. A graph supplied here was necessarily
-        /// evaluated before the diff was read, so that no longer holds.
-        /// </param>
         /// <param name="changedProjectsProvider"></param>
         public AffectedExecutor(
             AffectedOptions options,
-            ProjectGraph? graph = null,
             IChangesProvider? changesProvider = null,
             IChangedProjectsProvider? changedProjectsProvider = null)
+            : this(options, null, changesProvider, changedProjectsProvider)
+        {
+        }
+
+        private AffectedExecutor(
+            AffectedOptions options,
+            ProjectGraph? graph,
+            IChangesProvider? changesProvider,
+            IChangedProjectsProvider? changedProjectsProvider)
         {
             _context = new AffectedProcessorContext(options, graph, changesProvider, changedProjectsProvider);
         }
+
+        /// <summary>
+        /// Creates an executor that runs against a graph which has already been evaluated, instead
+        /// of building one.
+        /// </summary>
+        /// <remarks>
+        /// Note that not all features are available this way:
+        /// Deleted files are not attributed to their project since restoring them requires
+        /// evaluating the projects after the diff has been read, and a graph passed here was by
+        /// definition evaluated before it, so the files are simply absent from it.
+        /// </remarks>
+        /// <param name="options"></param>
+        /// <param name="graph"></param>
+        /// <param name="changesProvider"></param>
+        /// <param name="changedProjectsProvider"></param>
+        /// <returns>An executor bound to <paramref name="graph"/>.</returns>
+        internal static AffectedExecutor ForPreEvaluatedGraph(
+            AffectedOptions options,
+            ProjectGraph graph,
+            IChangesProvider? changesProvider = null,
+            IChangedProjectsProvider? changedProjectsProvider = null)
+            => new AffectedExecutor(options, graph, changesProvider, changedProjectsProvider);
 
         /// <inheritdoc />
         public AffectedSummary Execute() => new AffectedProcessor().Process(_context);

--- a/src/DotnetAffected.Core/AffectedExecutor.cs
+++ b/src/DotnetAffected.Core/AffectedExecutor.cs
@@ -26,7 +26,12 @@ namespace DotnetAffected.Core
         /// </summary>
         /// <param name="options"></param>
         /// <param name="changesProvider"></param>
-        /// <param name="graph"></param>
+        /// <param name="graph">
+        /// Leave this null unless you already have a graph you must reuse. When null, the graph is
+        /// built after the changed files are known, so files the diff removed are restored before
+        /// evaluation and stay attributed to their project. A graph supplied here was necessarily
+        /// evaluated before the diff was read, so that no longer holds.
+        /// </param>
         /// <param name="changedProjectsProvider"></param>
         public AffectedExecutor(
             AffectedOptions options,

--- a/src/DotnetAffected.Core/DotnetAffected.Core.csproj
+++ b/src/DotnetAffected.Core/DotnetAffected.Core.csproj
@@ -13,4 +13,13 @@
         <PackageReference Include="LibGit2Sharp" />
         <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" />
     </ItemGroup>
+
+    <ItemGroup>
+        <!-- The benchmarks need AffectedExecutor.ForPreEvaluatedGraph to keep graph construction
+             out of the measured region. It is not public: passing a graph evaluated before the
+             diff was read silently stops deleted files being attributed. -->
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>dotnet-affected.Benchmarks</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
 </Project>

--- a/src/DotnetAffected.Tasks/AffectedTask.cs
+++ b/src/DotnetAffected.Tasks/AffectedTask.cs
@@ -53,12 +53,12 @@ namespace DotnetAffected.Tasks
                         "DotnetAffected AssumeChanges is set along with FromRef/ToRef. Only AssumeChanges is used.");
                 }
 
-                var graph = new ProjectGraphFactory(affectedOptions).BuildProjectGraph();
-
+                // Deliberately no graph: the executor defers building it until the changed files
+                // are known, so files the diff removed are restored before evaluation and stay
+                // attributed to their project. Supplying one here opts out of that.
+                // See https://github.com/leonardochaia/dotnet-affected/issues/84
                 var executor = new AffectedExecutor(affectedOptions,
-                    graph,
-                    new GitChangesProvider(),
-                    new PredictionChangedProjectsProvider(graph, affectedOptions));
+                    changesProvider: new GitChangesProvider());
 
                 var results = executor.Execute();
                 var modifiedProjectInstances = new HashSet<ProjectInstance>();

--- a/src/dotnet-affected/Commands/Binding/InvocationContextExtensions.cs
+++ b/src/dotnet-affected/Commands/Binding/InvocationContextExtensions.cs
@@ -3,7 +3,6 @@ using DotnetAffected.Core;
 using System;
 using System.CommandLine.Binding;
 using System.CommandLine.Invocation;
-using System.Linq;
 
 namespace Affected.Cli.Commands
 {
@@ -13,12 +12,12 @@ namespace Affected.Cli.Commands
             this InvocationContext ctx)
         {
             var options = ctx.GetAffectedOptions();
-            var graph = new ProjectGraphFactory(options).BuildProjectGraph();
 
-            var executor = new AffectedExecutor(options,
-                graph,
-                new GitChangesProvider(),
-                new PredictionChangedProjectsProvider(graph, options));
+            // Deliberately no graph: the executor defers building it until the changed files are
+            // known, so files the diff removed are restored before evaluation and stay attributed
+            // to their project. Supplying one here opts out of that.
+            // See https://github.com/leonardochaia/dotnet-affected/issues/84
+            var executor = new AffectedExecutor(options, changesProvider: new GitChangesProvider());
 
             return (executor, options);
         }

--- a/test/dotnet-affected.Tests/DeletedFileDetectionTests.cs
+++ b/test/dotnet-affected.Tests/DeletedFileDetectionTests.cs
@@ -1,0 +1,46 @@
+using DotnetAffected.Testing.Utils;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Affected.Cli.Tests
+{
+    /// <summary>
+    /// Deleted files, exercised through the CLI rather than through the library.
+    ///
+    /// The overlay that restores deleted files before evaluation lives behind
+    /// AffectedProcessorContext's lazy graph, and the CLI supplies a pre-built graph, so the
+    /// library tests for this cover a path no frontend takes. See issue #84.
+    /// </summary>
+    public class DeletedFileDetectionTests : BaseInvocationTest
+    {
+        public DeletedFileDetectionTests(ITestOutputHelper helper)
+            : base(helper)
+        {
+        }
+
+        [Fact]
+        public async Task When_only_change_is_a_deleted_file_project_should_be_reported()
+        {
+            var projectName = "InventoryManagement";
+            var msBuildProject = this.Repository.CreateCsProject(projectName);
+
+            // Keep.cs stays behind so the project still has a compile item after the deletion.
+            await this.Repository.CreateTextFileAsync(
+                Path.Combine(projectName, "Class1.cs"), "public class Class1 {}");
+            await this.Repository.CreateTextFileAsync(
+                Path.Combine(projectName, "Keep.cs"), "public class Keep {}");
+
+            this.Repository.StageAndCommit();
+
+            this.Repository.DeleteFile(Path.Combine(projectName, "Class1.cs"));
+
+            var (output, exitCode) =
+                await this.InvokeAsync($"-p {Repository.Path} --dry-run --verbose -f text");
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(msBuildProject.FullPath, output);
+        }
+    }
+}


### PR DESCRIPTION
The overlay that restores deleted files before evaluation sits behind `AffectedProcessorContext`'s lazy graph. Both frontends built a graph up front and passed it in, so `_graph ??= BuildProjectGraph()` never ran and the overlay was never constructed.

Every deleted-file test builds its executor *without* a graph, so the test suite covered a path no frontend took. A commit that only deletes files reported nothing changed and exited **166**  telling CI to skip the build.

- Neither frontend passes a graph any more (#163 removed the last reason to).
- Adds a CLI-level regression test, since the gap was precisely that coverage stopped at the library.
- **BREAKING:** `AffectedExecutor`'s constructors no longer accept a `ProjectGraph`, and there's no public replacement. Reuse goes through the internal `AffectedExecutor.ForPreEvaluatedGraph`, named for the property that causes the bug. `DotnetAffected.Core` grants `InternalsVisibleTo` to `dotnet-affected.Benchmarks`, its only caller.

Consumers holding a graph should let the executor build its own: the cost is one evaluation, the alternative is silently wrong results. I don't expect any consumers of this so, since AFAIK everyone uses the CLI or Tasks