### PR TITLE
test(git-worktree): ensure running inside a git worktree works

### DIFF
--- a/test/DotnetAffected.Core.Tests/GitWorktreeDetectionTests.cs
+++ b/test/DotnetAffected.Core.Tests/GitWorktreeDetectionTests.cs
@@ -1,0 +1,122 @@
+using DotnetAffected.Abstractions;
+using DotnetAffected.Testing.Utils;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DotnetAffected.Core.Tests
+{
+    /// <summary>
+    /// Detection while running from inside a linked git worktree.
+    ///
+    /// A worktree splits the working directory from the git directory, so anything deriving one
+    /// from the other breaks here and nowhere else. Every other test in the suite runs against an
+    /// ordinary clone, which leaves the split entirely uncovered.
+    /// </summary>
+    public class GitWorktreeDetectionTests : BaseRepositoryTest
+    {
+        private const string ProjectName = "InventoryManagement";
+
+        private static AffectedSummary Execute(string repositoryPath, string fromRef = null)
+            => new AffectedExecutor(new AffectedOptions(repositoryPath, fromRef: fromRef)).Execute();
+
+        /// <summary>
+        /// Paths must resolve inside the worktree, not inside the repository it was linked from.
+        /// </summary>
+        [Fact]
+        public async Task When_running_inside_a_worktree_changed_project_should_be_detected()
+        {
+            this.Repository.CreateCsProject(ProjectName);
+            await this.Repository.CreateTextFileAsync(
+                Path.Combine(ProjectName, "Keep.cs"), "public class Keep {}");
+            this.Repository.StageAndCommit();
+
+            using var worktree = new TemporaryWorktree(this.Repository);
+
+            await File.WriteAllTextAsync(
+                Path.Combine(worktree.Path, ProjectName, "Keep.cs"), "// changed inside the worktree");
+
+            var summary = Execute(worktree.Path);
+
+            var changed = Assert.Single(summary.ProjectsWithChangedFiles);
+            Assert.Equal(
+                Path.Combine(worktree.Path, ProjectName, $"{ProjectName}.csproj"),
+                changed.GetFullPath());
+        }
+
+        /// <summary>
+        /// Restoring a deleted file reads its content back out of the commit and matches it against
+        /// the working directory, which is exactly the pair a worktree separates.
+        /// </summary>
+        [Fact]
+        public async Task When_running_inside_a_worktree_deleted_file_should_be_attributed()
+        {
+            this.Repository.CreateCsProject(ProjectName);
+            await this.Repository.CreateTextFileAsync(
+                Path.Combine(ProjectName, "Gone.cs"), "public class Gone {}");
+            await this.Repository.CreateTextFileAsync(
+                Path.Combine(ProjectName, "Keep.cs"), "public class Keep {}");
+            this.Repository.StageAndCommit();
+
+            using var worktree = new TemporaryWorktree(this.Repository);
+
+            File.Delete(Path.Combine(worktree.Path, ProjectName, "Gone.cs"));
+
+            var summary = Execute(worktree.Path);
+
+            Assert.Single(summary.FilesThatChanged);
+
+            var changed = Assert.Single(summary.ProjectsWithChangedFiles);
+            Assert.Equal(
+                Path.Combine(worktree.Path, ProjectName, $"{ProjectName}.csproj"),
+                changed.GetFullPath());
+        }
+
+        /// <summary>
+        /// Comparing against a ref resolves commits through the repository the worktree is linked
+        /// to, while the files being compared live in the worktree.
+        /// </summary>
+        [Fact]
+        public async Task When_running_inside_a_worktree_changes_between_commits_should_be_detected()
+        {
+            this.Repository.CreateCsProject(ProjectName);
+            var baseCommit = this.Repository.StageAndCommit();
+
+            using var worktree = new TemporaryWorktree(this.Repository);
+
+            await File.WriteAllTextAsync(
+                Path.Combine(worktree.Path, ProjectName, "Added.cs"), "public class Added {}");
+            worktree.StageAndCommit();
+
+            var summary = Execute(worktree.Path, fromRef: baseCommit.Sha);
+
+            var changed = Assert.Single(summary.ProjectsWithChangedFiles);
+            Assert.Equal(
+                Path.Combine(worktree.Path, ProjectName, $"{ProjectName}.csproj"),
+                changed.GetFullPath());
+        }
+
+        /// <summary>
+        /// Changes made in the repository the worktree came from are not the worktree's changes.
+        /// </summary>
+        [Fact]
+        public async Task When_running_inside_a_worktree_changes_outside_it_should_be_ignored()
+        {
+            this.Repository.CreateCsProject(ProjectName);
+            await this.Repository.CreateTextFileAsync(
+                Path.Combine(ProjectName, "Keep.cs"), "public class Keep {}");
+            this.Repository.StageAndCommit();
+
+            using var worktree = new TemporaryWorktree(this.Repository);
+
+            // Touch the original checkout only.
+            await this.Repository.CreateTextFileAsync(
+                Path.Combine(ProjectName, "Keep.cs"), "// changed outside the worktree");
+
+            var summary = Execute(worktree.Path);
+
+            Assert.Empty(summary.FilesThatChanged);
+            Assert.Empty(summary.ProjectsWithChangedFiles);
+        }
+    }
+}

--- a/test/DotnetAffected.Testing.Utils/Repository/TemporaryWorktree.cs
+++ b/test/DotnetAffected.Testing.Utils/Repository/TemporaryWorktree.cs
@@ -1,0 +1,78 @@
+using LibGit2Sharp;
+using System;
+
+namespace DotnetAffected.Testing.Utils
+{
+    /// <summary>
+    /// A linked git worktree of a <see cref="TemporaryRepository"/>.
+    ///
+    /// In a worktree the working directory and the git directory live apart: the checkout has a
+    /// <c>.git</c> file pointing at an admin directory inside the original repository. Anything
+    /// deriving paths from one while assuming the other silently misbehaves, so the scenario is
+    /// worth exercising rather than assuming.
+    /// </summary>
+    public sealed class TemporaryWorktree : IDisposable
+    {
+        private readonly TempWorkingDirectory _directory;
+
+        /// <summary>
+        /// Adds a worktree of <paramref name="repository"/>, checked out on a new branch.
+        /// </summary>
+        /// <param name="repository">Repository to link the worktree to.</param>
+        /// <param name="branchName">Branch created for the worktree.</param>
+        public TemporaryWorktree(TemporaryRepository repository, string branchName = "worktree")
+        {
+            _directory = new TempWorkingDirectory();
+
+            // REMARKS: the worktree deliberately lives outside the repository. Nesting it would
+            // put a second copy of every project underneath the repository root, which project
+            // discovery would then find alongside the originals.
+            var path = System.IO.Path.Combine(_directory.Path, branchName);
+
+            repository.Repository.Worktrees.Add(branchName, path, false);
+
+            // REMARKS: LibGit2Sharp writes the worktree's administrative files but leaves the
+            // working directory empty, and its overload that takes a committish checks out in the
+            // original repository instead, which fails with "cannot set HEAD to reference ... as it
+            // is the current HEAD of a linked repository". Resetting hard from inside the worktree
+            // populates it from its own HEAD without moving any reference.
+            string workingDirectory;
+            using (var worktreeRepository = new Repository(path))
+            {
+                worktreeRepository.Reset(ResetMode.Hard);
+                workingDirectory = worktreeRepository.Info.WorkingDirectory;
+            }
+
+            // Taken from git rather than from the path we composed, for the same reason
+            // TemporaryRepository does it: on OSX the temp directory is reached through a symlink,
+            // so "/var/x" and the "/private/var/x" git reports are the same place spelled two ways.
+            // Handing tests the resolved spelling keeps them about worktrees, leaving the unresolved
+            // spelling to SymlinkedRepositoryPathTests.
+            Path = System.IO.Path.TrimEndingDirectorySeparator(workingDirectory);
+        }
+
+        /// <summary>
+        /// Gets the root of the worktree's checkout.
+        /// </summary>
+        public string Path { get; }
+
+        /// <summary>
+        /// Stages and commits everything in the worktree, onto the worktree's own branch.
+        /// </summary>
+        public Commit StageAndCommit(string message = null)
+        {
+            using var repository = new Repository(Path);
+
+            Commands.Stage(repository, "*");
+
+            var author = new Signature("Leo", "lchaia@outlook.com", DateTime.Now);
+            return repository.Commit(message ?? Guid.NewGuid()
+                .ToString("N"), author, author);
+        }
+
+        public void Dispose()
+        {
+            _directory.Dispose();
+        }
+    }
+}

--- a/test/dotnet-affected.Tests/GitWorktreeCliTests.cs
+++ b/test/dotnet-affected.Tests/GitWorktreeCliTests.cs
@@ -1,0 +1,73 @@
+using DotnetAffected.Testing.Utils;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Affected.Cli.Tests
+{
+    /// <summary>
+    /// The CLI run from inside a linked git worktree.
+    ///
+    /// Covered separately from the library tests on purpose: the frontends and the library reached
+    /// the project graph by different routes, and that is precisely how deleted files stayed broken
+    /// for the CLI while the library suite was green. See issue #84.
+    /// </summary>
+    public class GitWorktreeCliTests : BaseInvocationTest
+    {
+        private const string ProjectName = "InventoryManagement";
+
+        public GitWorktreeCliTests(ITestOutputHelper helper)
+            : base(helper)
+        {
+        }
+
+        [Fact]
+        public async Task When_running_inside_a_worktree_changed_project_should_be_reported()
+        {
+            this.Repository.CreateCsProject(ProjectName);
+            await this.Repository.CreateTextFileAsync(
+                Path.Combine(ProjectName, "Keep.cs"), "public class Keep {}");
+            this.Repository.StageAndCommit();
+
+            using var worktree = new TemporaryWorktree(this.Repository);
+
+            await File.WriteAllTextAsync(
+                Path.Combine(worktree.Path, ProjectName, "Keep.cs"), "// changed inside the worktree");
+
+            var (output, exitCode) = await this.InvokeAsync($"-p {worktree.Path} --dry-run -f text");
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(
+                Path.Combine(worktree.Path, ProjectName, $"{ProjectName}.csproj"),
+                output);
+        }
+
+        /// <summary>
+        /// Deleting a file is attributed through the overlay, which reads the file back out of the
+        /// commit. Doing that from a worktree exercises the overlay and the split git directory at
+        /// the same time, which is the combination a monorepo CI actually runs.
+        /// </summary>
+        [Fact]
+        public async Task When_running_inside_a_worktree_deleted_file_should_be_reported()
+        {
+            this.Repository.CreateCsProject(ProjectName);
+            await this.Repository.CreateTextFileAsync(
+                Path.Combine(ProjectName, "Gone.cs"), "public class Gone {}");
+            await this.Repository.CreateTextFileAsync(
+                Path.Combine(ProjectName, "Keep.cs"), "public class Keep {}");
+            this.Repository.StageAndCommit();
+
+            using var worktree = new TemporaryWorktree(this.Repository);
+
+            File.Delete(Path.Combine(worktree.Path, ProjectName, "Gone.cs"));
+
+            var (output, exitCode) = await this.InvokeAsync($"-p {worktree.Path} --dry-run -f text");
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(
+                Path.Combine(worktree.Path, ProjectName, $"{ProjectName}.csproj"),
+                output);
+        }
+    }
+}


### PR DESCRIPTION
Adds tests to ensure that inside a git worktree works ok. AI agents most used environment.