### PR TITLE
refactor: give output formatters a context

### DIFF
--- a/src/dotnet-affected/Commands/AffectedRootCommand.cs
+++ b/src/dotnet-affected/Commands/AffectedRootCommand.cs
@@ -61,6 +61,7 @@ namespace Affected.Cli.Commands
                     outputOptions.Formatters,
                     outputOptions.OutputDir,
                     outputOptions.OutputName,
+                    options.FilterFilePath,
                     outputOptions.DryRun,
                     verbose);
             });

--- a/src/dotnet-affected/Domain/IOutputFormatter.cs
+++ b/src/dotnet-affected/Domain/IOutputFormatter.cs
@@ -25,7 +25,8 @@ namespace Affected.Cli
         /// into an specific output.
         /// </summary>
         /// <param name="projects">List of projects to format.</param>
+        /// <param name="context">Information about the output being generated.</param>
         /// <returns>The formatted output.</returns>
-        Task<string> Format(IEnumerable<IProjectInfo> projects);
+        Task<string> Format(IEnumerable<IProjectInfo> projects, OutputFormatterContext context);
     }
 }

--- a/src/dotnet-affected/Domain/OutputFormatterContext.cs
+++ b/src/dotnet-affected/Domain/OutputFormatterContext.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+namespace Affected.Cli
+{
+    /// <summary>
+    /// Information about the output being generated, for
+    /// <see cref="IOutputFormatter"/>s that need more than the list of projects.
+    /// </summary>
+    public sealed class OutputFormatterContext
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="OutputFormatterContext"/>.
+        /// </summary>
+        /// <param name="outputPath">Full path to the file being written.</param>
+        /// <param name="filterFilePath">Path to the filter file projects were discovered from, if any.</param>
+        public OutputFormatterContext(string outputPath, string? filterFilePath = null)
+        {
+            if (string.IsNullOrWhiteSpace(outputPath))
+            {
+                throw new ArgumentException("A path to the output file is required.", nameof(outputPath));
+            }
+
+            OutputPath = outputPath;
+            FilterFilePath = filterFilePath;
+        }
+
+        /// <summary>
+        /// Gets the full path to the file being written.
+        /// Formatters writing paths should make them relative to its directory,
+        /// so that the file stays portable.
+        /// </summary>
+        public string OutputPath { get; }
+
+        /// <summary>
+        /// Gets the path to the filter file the projects were discovered from,
+        /// which is <c>null</c> when projects were discovered from the file system.
+        /// </summary>
+        public string? FilterFilePath { get; }
+    }
+}

--- a/src/dotnet-affected/Infrastructure/Formatters/JsonOutputFormatter.cs
+++ b/src/dotnet-affected/Infrastructure/Formatters/JsonOutputFormatter.cs
@@ -15,7 +15,7 @@ namespace Affected.Cli.Formatters
             WriteIndented = true
         };
 
-        public Task<string> Format(IEnumerable<IProjectInfo> projects)
+        public Task<string> Format(IEnumerable<IProjectInfo> projects, OutputFormatterContext context)
         {
             return Task.FromResult(JsonSerializer.Serialize(projects, SerializerOptions));
         }

--- a/src/dotnet-affected/Infrastructure/Formatters/TextOutputFormatter.cs
+++ b/src/dotnet-affected/Infrastructure/Formatters/TextOutputFormatter.cs
@@ -10,7 +10,7 @@ namespace Affected.Cli.Formatters
         
         public string NewFileExtension => ".txt";
 
-        public Task<string> Format(IEnumerable<IProjectInfo> projects)
+        public Task<string> Format(IEnumerable<IProjectInfo> projects, OutputFormatterContext context)
         {
             var builder = new StringBuilder();
 

--- a/src/dotnet-affected/Infrastructure/Formatters/TraversalProjectOutputFormatter.cs
+++ b/src/dotnet-affected/Infrastructure/Formatters/TraversalProjectOutputFormatter.cs
@@ -13,7 +13,7 @@ namespace Affected.Cli.Formatters
         public string Type => "traversal";
         public string NewFileExtension => ".proj";
 
-        public Task<string> Format(IEnumerable<IProjectInfo> projects)
+        public Task<string> Format(IEnumerable<IProjectInfo> projects, OutputFormatterContext context)
         {
             var projectRootElement = @"<Project Sdk=""Microsoft.Build.Traversal/4.1.82""></Project>";
             var stringReader = new StringReader(projectRootElement);

--- a/src/dotnet-affected/Infrastructure/OutputFormatterExecutor.cs
+++ b/src/dotnet-affected/Infrastructure/OutputFormatterExecutor.cs
@@ -30,6 +30,7 @@ namespace Affected.Cli
             IEnumerable<string> formatters,
             string outputDirectory,
             string outputName,
+            string? filterFilePath,
             bool dryRun,
             bool verbose = false)
         {
@@ -49,16 +50,16 @@ namespace Affected.Cli
                     throw new InvalidOperationException("Couldn't find formatter of type: " + type);
                 }
 
-                // Format the projects and calculate output path.
-                var outputContents = await formatter.Format(allProjects);
+                var outputFileName = outputName + formatter.NewFileExtension;
+                var outputPath = Path.Combine(outputDirectory, outputFileName);
+
+                var outputContents = await formatter.Format(allProjects,
+                    new OutputFormatterContext(outputPath, filterFilePath));
 
                 if (string.IsNullOrWhiteSpace(outputContents))
                 {
                     throw new InvalidOperationException($"Formatter {type} returned no output");
                 }
-
-                var outputFileName = outputName + formatter.NewFileExtension;
-                var outputPath = Path.Combine(outputDirectory, outputFileName);
 
                 if (dryRun)
                 {

--- a/test/dotnet-affected.Tests/Formatters/FormatterExecutorTests.cs
+++ b/test/dotnet-affected.Tests/Formatters/FormatterExecutorTests.cs
@@ -33,7 +33,7 @@ namespace Affected.Cli.Tests.Formatters
             await executor.Execute(projects, new[]
             {
                 formatterType
-            }, Repository.Path, "affected", false, true);
+            }, Repository.Path, "affected", null, false, true);
 
             var outputPath = Path.Combine(Repository.Path, "affected.txt");
             var outputContents = await File.ReadAllTextAsync(outputPath);
@@ -63,7 +63,7 @@ namespace Affected.Cli.Tests.Formatters
             await executor.Execute(projects, new[]
             {
                 formatterType
-            }, Repository.Path, outputFileName, false, true);
+            }, Repository.Path, outputFileName, null, false, true);
 
             // Assert
             var outputPath = Path.Combine(Repository.Path, $"{outputFileName}.txt");

--- a/test/dotnet-affected.Tests/Formatters/FormatterTestContext.cs
+++ b/test/dotnet-affected.Tests/Formatters/FormatterTestContext.cs
@@ -1,0 +1,14 @@
+﻿using System.IO;
+
+namespace Affected.Cli.Tests.Formatters
+{
+    internal static class FormatterTestContext
+    {
+        /// <summary>
+        /// Formatters that don't care where their output lands get a throwaway
+        /// context, so that their tests stay about the format itself.
+        /// </summary>
+        public static OutputFormatterContext Default { get; } =
+            new OutputFormatterContext(Path.Combine(Path.GetTempPath(), "affected"));
+    }
+}

--- a/test/dotnet-affected.Tests/Formatters/JsonFormatterTests.cs
+++ b/test/dotnet-affected.Tests/Formatters/JsonFormatterTests.cs
@@ -19,7 +19,7 @@ namespace Affected.Cli.Tests.Formatters
                 new ProjectInfo("TestProject", projectPath)
             };
 
-            var output = await formatter.Format(projects);
+            var output = await formatter.Format(projects, FormatterTestContext.Default);
 
             Assert.Equal(JsonSerializer.Serialize(projects, JsonOutputFormatter.SerializerOptions), output);
         }
@@ -36,7 +36,7 @@ namespace Affected.Cli.Tests.Formatters
                 new ProjectInfo("TestProject", firstProjectPath), new ProjectInfo("OtherTest", secondProjectPath)
             };
 
-            var output = await formatter.Format(projects);
+            var output = await formatter.Format(projects, FormatterTestContext.Default);
 
             Assert.Equal(JsonSerializer.Serialize(projects, JsonOutputFormatter.SerializerOptions), output);
         }

--- a/test/dotnet-affected.Tests/Formatters/OutputFormatterContextTests.cs
+++ b/test/dotnet-affected.Tests/Formatters/OutputFormatterContextTests.cs
@@ -1,0 +1,90 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Affected.Cli.Tests.Formatters
+{
+    /// <summary>
+    /// Ensures the executor hands formatters everything they need to write
+    /// paths relative to the file being created.
+    /// </summary>
+    public class OutputFormatterContextTests
+        : BaseInvocationTest
+    {
+        public OutputFormatterContextTests(ITestOutputHelper helper)
+            : base(helper)
+        {
+        }
+
+        private class CapturingOutputFormatter : IOutputFormatter
+        {
+            public OutputFormatterContext Captured { get; private set; }
+
+            public string Type => "capturing";
+
+            public string NewFileExtension => ".captured";
+
+            public Task<string> Format(IEnumerable<IProjectInfo> projects, OutputFormatterContext context)
+            {
+                Captured = context;
+                return Task.FromResult("captured");
+            }
+        }
+
+        private async Task<OutputFormatterContext> CaptureContext(string filterFilePath)
+        {
+            var formatter = new CapturingOutputFormatter();
+            var executor = new OutputFormatterExecutor(new[]
+            {
+                formatter
+            }, this.Terminal);
+
+            await executor.Execute(new[]
+                {
+                    new ProjectInfo("TestProject", "/home/dev/test/test.csproj")
+                },
+                new[]
+                {
+                    "capturing"
+                },
+                Repository.Path,
+                "affected",
+                filterFilePath,
+                dryRun: true,
+                verbose: true);
+
+            Assert.NotNull(formatter.Captured);
+            return formatter.Captured;
+        }
+
+        [Fact]
+        public async Task Should_receive_the_path_of_the_file_being_written()
+        {
+            var context = await CaptureContext(null);
+
+            // Includes the formatter's own extension, since that is the file
+            // formatters have to make their paths relative to.
+            Assert.Equal(Path.Combine(Repository.Path, "affected.captured"), context.OutputPath);
+        }
+
+        [Fact]
+        public async Task Should_receive_the_filter_file_path()
+        {
+            var filterFilePath = Path.Combine(Repository.Path, "test-solution.slnx");
+
+            var context = await CaptureContext(filterFilePath);
+
+            Assert.Equal(filterFilePath, context.FilterFilePath);
+        }
+
+        [Fact]
+        public async Task Should_receive_no_filter_file_path_when_discovering_from_disk()
+        {
+            var context = await CaptureContext(null);
+
+            Assert.Null(context.FilterFilePath);
+        }
+    }
+}

--- a/test/dotnet-affected.Tests/Formatters/TextFormatterTests.cs
+++ b/test/dotnet-affected.Tests/Formatters/TextFormatterTests.cs
@@ -17,7 +17,7 @@ namespace Affected.Cli.Tests.Formatters
                 new ProjectInfo("TestProject", projectPath)
             };
 
-            var output = await formatter.Format(projects);
+            var output = await formatter.Format(projects, FormatterTestContext.Default);
 
             Assert.Contains(projectPath, output);
         }
@@ -34,7 +34,7 @@ namespace Affected.Cli.Tests.Formatters
                 new ProjectInfo("TestProject", firstProjectPath), new ProjectInfo("OtherTest", secondProjectPath)
             };
 
-            var output = await formatter.Format(projects);
+            var output = await formatter.Format(projects, FormatterTestContext.Default);
 
             Assert.Contains(firstProjectPath, output);
             Assert.Contains(secondProjectPath, output);

--- a/test/dotnet-affected.Tests/Formatters/TraversalFormatterTests.cs
+++ b/test/dotnet-affected.Tests/Formatters/TraversalFormatterTests.cs
@@ -18,7 +18,7 @@ namespace Affected.Cli.Tests.Formatters
                 new ProjectInfo("TestProject", projectPath)
             };
 
-            var output = await formatter.Format(projects);
+            var output = await formatter.Format(projects, FormatterTestContext.Default);
 
             CustomAssertions.LineSequenceEquals(output,
                 l => Assert.Contains("Microsoft.Build.Traversal/4.1.82", l),
@@ -41,7 +41,7 @@ namespace Affected.Cli.Tests.Formatters
                 new ProjectInfo("TestProject", firstProjectPath), new ProjectInfo("OtherTest", secondProjectPath)
             };
 
-            var output = await formatter.Format(projects);
+            var output = await formatter.Format(projects, FormatterTestContext.Default);
 
             CustomAssertions.LineSequenceEquals(output,
                 l => Assert.Contains("Microsoft.Build.Traversal/4.1.82", l),


### PR DESCRIPTION
This allows the formatter to have more context to provide it's output. Particularly giving access to the output path and the filter file path