### PR TITLE
feat: add solution filter file output

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,17 @@ dotnet-affected currently supports following **format options**:
 - `traversal`: Traversal SDK project file.
 - `text`: Plain text file containing all affected project paths.
 - `json`: JSON file containing all affected project names and paths.
+- `slnf`: [Solution Filter](https://learn.microsoft.com/en-us/visualstudio/msbuild/solution-filters) narrowing a Solution down to the affected projects.
+
+The `slnf` format needs a Solution to reference, so it requires `--filter-file-path` to
+point at a Solution (`.sln`, `.slnx`) or at another Solution Filter (`.slnf`), in which
+case the generated filter references the same Solution. Paths are written relative to
+the generated file, so it stays valid wherever `--output-dir` puts it:
+
+```text
+$ dotnet affected --filter-file-path Application.slnx --format slnf
+$ dotnet test --solution affected.slnf
+```
 
 Example:
 ```text

--- a/src/DotnetAffected.Core/ProjectDiscovery/SolutionFilterProjectDiscoverer.cs
+++ b/src/DotnetAffected.Core/ProjectDiscovery/SolutionFilterProjectDiscoverer.cs
@@ -15,7 +15,7 @@ namespace DotnetAffected.Core
             // but this makes the warning go away.
             ArgumentNullException.ThrowIfNull(options.FilterFilePath);
 
-            return SolutionFilter.Load(options.FilterFilePath).ProjectPaths;
+            return SolutionFilter.LoadFromFile(options.FilterFilePath).ProjectPaths;
         }
     }
 }

--- a/src/DotnetAffected.Core/SolutionFilter.cs
+++ b/src/DotnetAffected.Core/SolutionFilter.cs
@@ -58,11 +58,56 @@ namespace DotnetAffected.Core
         public IReadOnlyList<string> ProjectPaths { get; }
 
         /// <summary>
+        /// Gets whether a filter can be created referencing <paramref name="filterFilePath"/>.
+        /// Inspects the path only, nothing is read.
+        /// </summary>
+        /// <param name="filterFilePath">Path to a solution or solution filter, if any.</param>
+        /// <returns>Whether <see cref="Create"/> would succeed.</returns>
+        public static bool CanCreateFrom(string? filterFilePath)
+        {
+            if (string.IsNullOrWhiteSpace(filterFilePath))
+            {
+                return false;
+            }
+
+            return filterFilePath!.EndsWith(".sln")
+                   || filterFilePath.EndsWith(".slnx")
+                   || filterFilePath.EndsWith(".slnf");
+        }
+
+        /// <summary>
+        /// Creates a filter over <paramref name="projectPaths"/>, referencing the
+        /// solution behind <paramref name="filterFilePath"/>.
+        /// </summary>
+        /// <remarks>
+        /// Filtering an existing solution filter narrows it down,
+        /// both end up referencing the same solution.
+        /// </remarks>
+        /// <param name="filterFilePath">Path to a solution (.sln, .slnx) or solution filter (.slnf).</param>
+        /// <param name="projectPaths">Paths to the projects to include.</param>
+        /// <returns>The new <see cref="SolutionFilter"/>, which has not been written anywhere.</returns>
+        public static SolutionFilter Create(string? filterFilePath, IEnumerable<string> projectPaths)
+        {
+            if (!CanCreateFrom(filterFilePath))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot create a solution filter referencing {filterFilePath ?? "nothing"}: " +
+                    "a solution (.sln, .slnx) or another solution filter (.slnf) is required.");
+            }
+
+            var solutionPath = filterFilePath!.EndsWith(".slnf")
+                ? LoadFromFile(filterFilePath).SolutionPath
+                : filterFilePath;
+
+            return new SolutionFilter(solutionPath, projectPaths);
+        }
+
+        /// <summary>
         /// Reads a solution filter from disk.
         /// </summary>
         /// <param name="filterFilePath">Path to the <c>.slnf</c> file.</param>
         /// <returns>The parsed <see cref="SolutionFilter"/>.</returns>
-        public static SolutionFilter Load(string filterFilePath)
+        public static SolutionFilter LoadFromFile(string filterFilePath)
         {
             if (string.IsNullOrWhiteSpace(filterFilePath))
             {

--- a/src/dotnet-affected/Commands/AffectedRootCommand.cs
+++ b/src/dotnet-affected/Commands/AffectedRootCommand.cs
@@ -1,4 +1,6 @@
 ﻿using Affected.Cli.Views;
+using DotnetAffected.Core;
+using System;
 using System.CommandLine;
 using System.CommandLine.Rendering;
 using System.Linq;
@@ -76,13 +78,39 @@ namespace Affected.Cli.Commands
                 "--format", "-f"
             })
         {
-            this.Description = "Space-seperated output file formats. Possible values: <traversal, text, json>.";
+            this.Description = "Space-seperated output file formats. Possible values: <traversal, text, json, slnf>.";
 
             this.SetDefaultValue(new[]
             {
                 "traversal"
             });
             this.AllowMultipleArgumentsPerToken = true;
+
+            // slnf is the only format referencing a file other than its own,
+            // fail at parse time instead of after building the whole graph.
+            this.AddValidator(optionResult =>
+            {
+                var formats = optionResult.GetValueOrDefault<string[]>();
+                if (formats is null || !formats.Any(format =>
+                        format.Equals("slnf", StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    return;
+                }
+
+                // --solution-path is the deprecated alias of --filter-file-path.
+                var filterFilePath =
+                    optionResult.FindResultFor(AffectedGlobalOptions.FilterFilePathOption)
+                        ?.GetValueOrDefault<string>()
+                    ?? optionResult.FindResultFor(AffectedGlobalOptions.SolutionPathOption)
+                        ?.GetValueOrDefault<string>();
+
+                if (!SolutionFilter.CanCreateFrom(filterFilePath))
+                {
+                    optionResult.ErrorMessage =
+                        "The slnf format needs a Solution to reference. Point --filter-file-path at " +
+                        "a Solution (.sln, .slnx) or a Solution Filter (.slnf).";
+                }
+            });
         }
     }
 

--- a/src/dotnet-affected/Infrastructure/Formatters/SolutionFilterFileOutputFormatter.cs
+++ b/src/dotnet-affected/Infrastructure/Formatters/SolutionFilterFileOutputFormatter.cs
@@ -1,0 +1,27 @@
+﻿using DotnetAffected.Core;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Affected.Cli.Formatters
+{
+    /// <summary>
+    /// Writes a Solution Filter file (.slnf) narrowing the Solution
+    /// down to the affected projects.
+    /// </summary>
+    internal class SolutionFilterFileOutputFormatter : IOutputFormatter
+    {
+        public string Type => "slnf";
+
+        public string NewFileExtension => ".slnf";
+
+        public Task<string> Format(IEnumerable<IProjectInfo> projects, OutputFormatterContext context)
+        {
+            var filter = SolutionFilter.Create(context.FilterFilePath, projects.Select(p => p.FilePath));
+
+            // Paths are made relative to the file being written, so that
+            // the filter stays usable wherever the output directory is.
+            return Task.FromResult(filter.ToJson(context.OutputPath));
+        }
+    }
+}

--- a/src/dotnet-affected/Infrastructure/OutputFormatters.cs
+++ b/src/dotnet-affected/Infrastructure/OutputFormatters.cs
@@ -6,7 +6,8 @@ namespace Affected.Cli
     {
         public static readonly IOutputFormatter[] All =
         {
-            new TextOutputFormatter(), new TraversalProjectOutputFormatter(), new JsonOutputFormatter()
+            new TextOutputFormatter(), new TraversalProjectOutputFormatter(), new JsonOutputFormatter(),
+            new SolutionFilterFileOutputFormatter()
         };
     }
 }

--- a/test/DotnetAffected.Core.Tests/SolutionFilterTests.cs
+++ b/test/DotnetAffected.Core.Tests/SolutionFilterTests.cs
@@ -193,7 +193,7 @@ namespace DotnetAffected.Core.Tests
                     })
                     .SaveAsync(filterFilePath);
 
-                var loaded = SolutionFilter.Load(filterFilePath);
+                var loaded = SolutionFilter.LoadFromFile(filterFilePath);
 
                 Assert.Equal(Path.GetFullPath(solutionPath), loaded.SolutionPath);
                 Assert.Equal(new[]
@@ -211,6 +211,83 @@ namespace DotnetAffected.Core.Tests
         public void Constructor_should_require_a_solution_path()
         {
             Assert.Throws<ArgumentException>(() => new SolutionFilter("", Array.Empty<string>()));
+        }
+
+        [Theory]
+        [InlineData("Application.sln", true)]
+        [InlineData("Application.slnx", true)]
+        [InlineData("ci.slnf", true)]
+        [InlineData("dirs.proj", false)]
+        [InlineData("Application.csproj", false)]
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        public void CanCreateFrom_should_only_accept_what_references_a_solution(string filterFilePath, bool expected)
+        {
+            Assert.Equal(expected, SolutionFilter.CanCreateFrom(filterFilePath));
+        }
+
+        [Theory]
+        [InlineData("Application.sln")]
+        [InlineData("Application.slnx")]
+        public void Create_from_a_solution_should_reference_it(string solutionName)
+        {
+            var solutionPath = PathIn(solutionName);
+            var projectPath = PathIn("Libs", "Lib.csproj");
+
+            var filter = SolutionFilter.Create(solutionPath, new[]
+            {
+                projectPath
+            });
+
+            Assert.Equal(solutionPath, filter.SolutionPath);
+            Assert.Equal(new[]
+            {
+                projectPath
+            }, filter.ProjectPaths);
+        }
+
+        [Fact]
+        public async Task Create_from_an_existing_filter_should_reference_the_same_solution()
+        {
+            var directory = Path.Combine(Path.GetTempPath(), $"dotnet-affected-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(directory);
+
+            try
+            {
+                var solutionPath = Path.Combine(directory, "Application.slnx");
+                var existingFilterPath = Path.Combine(directory, "ci.slnf");
+
+                await new SolutionFilter(solutionPath, new[]
+                    {
+                        Path.Combine(directory, "Libs", "Lib.csproj")
+                    })
+                    .SaveAsync(existingFilterPath);
+
+                // Narrowing a filter down still references the solution, not the filter.
+                var filter = SolutionFilter.Create(existingFilterPath, new[]
+                {
+                    Path.Combine(directory, "Libs", "Lib.csproj")
+                });
+
+                Assert.Equal(solutionPath, filter.SolutionPath);
+            }
+            finally
+            {
+                Directory.Delete(directory, true);
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("dirs.proj")]
+        public void Create_without_a_solution_to_reference_should_throw(string filterFilePath)
+        {
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => SolutionFilter.Create(filterFilePath, Array.Empty<string>()));
+
+            Assert.Contains("a solution (.sln, .slnx) or another solution filter (.slnf) is required",
+                exception.Message);
         }
     }
 }

--- a/test/dotnet-affected.Tests/Formatters/SolutionFilterFileFormatterTests.cs
+++ b/test/dotnet-affected.Tests/Formatters/SolutionFilterFileFormatterTests.cs
@@ -1,0 +1,77 @@
+﻿using Affected.Cli.Formatters;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Affected.Cli.Tests.Formatters
+{
+    /// <summary>
+    /// Resolving which solution gets referenced belongs to SolutionFilter,
+    /// these cover what the formatter itself is responsible for.
+    /// </summary>
+    public class SolutionFilterFileFormatterTests
+    {
+        private static readonly string Root =
+            Path.GetFullPath(Path.Combine(Path.GetTempPath(), "slnf-formatter-tests"));
+
+        private static string PathIn(params string[] parts)
+        {
+            return Path.GetFullPath(Path.Combine(Root, Path.Combine(parts)));
+        }
+
+        private static string NormalizeNewLines(string value)
+        {
+            return value.Replace("\r\n", "\n");
+        }
+
+        [Fact]
+        public async Task Should_reference_the_solution_and_the_affected_projects()
+        {
+            var formatter = new SolutionFilterFileOutputFormatter();
+            var solutionPath = PathIn("Application.slnx");
+            var outputPath = PathIn("affected.slnf");
+
+            var projects = new[]
+            {
+                new ProjectInfo("StringUtils", PathIn("Libs", "StringUtils", "StringUtils.csproj")),
+                new ProjectInfo("Web", PathIn("Apps", "Web", "Web.csproj"))
+            };
+
+            var output = await formatter.Format(projects, new OutputFormatterContext(outputPath, solutionPath));
+
+            var expected = string.Join("\n",
+                "{",
+                "  \"solution\": {",
+                "    \"path\": \"Application.slnx\",",
+                "    \"projects\": [",
+                "      \"Libs\\\\StringUtils\\\\StringUtils.csproj\",",
+                "      \"Apps\\\\Web\\\\Web.csproj\"",
+                "    ]",
+                "  }",
+                "}");
+
+            Assert.Equal(expected, NormalizeNewLines(output));
+        }
+
+        [Fact]
+        public async Task Should_reference_the_solution_relative_to_the_output_file()
+        {
+            // The realistic CI shape: the filter is generated into an output
+            // directory, so it has to point back up at the solution.
+            var formatter = new SolutionFilterFileOutputFormatter();
+            var solutionPath = PathIn("Application.slnx");
+            var outputPath = PathIn("artifacts", "affected.slnf");
+
+            var projects = new[]
+            {
+                new ProjectInfo("StringUtils", PathIn("Libs", "StringUtils", "StringUtils.csproj"))
+            };
+
+            var output = await formatter.Format(projects, new OutputFormatterContext(outputPath, solutionPath));
+
+            Assert.Contains("\"path\": \"..\\\\Application.slnx\"", output);
+            // Projects stay relative to the solution, not to the output file.
+            Assert.Contains("\"Libs\\\\StringUtils\\\\StringUtils.csproj\"", output);
+        }
+    }
+}

--- a/test/dotnet-affected.Tests/SolutionFilterOutputCliTests.cs
+++ b/test/dotnet-affected.Tests/SolutionFilterOutputCliTests.cs
@@ -1,0 +1,123 @@
+﻿using DotnetAffected.Core;
+using DotnetAffected.Testing.Utils;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Affected.Cli.Tests
+{
+    /// <summary>
+    /// Tests for generating Solution Filter files from the CLI.
+    /// </summary>
+    public class SolutionFilterOutputCliTests : BaseInvocationTest
+    {
+        public SolutionFilterOutputCliTests(ITestOutputHelper helper)
+            : base(helper)
+        {
+        }
+
+        [Fact]
+        public async Task Should_create_a_filter_referencing_the_solution()
+        {
+            var msBuildProject = this.Repository.CreateCsProject("InventoryManagement");
+            var solutionName = "test-solution.slnx";
+            await this.Repository.CreateXmlSolutionAsync(solutionName, msBuildProject.FullPath);
+
+            var solutionPath = Path.Combine(Repository.Path, solutionName);
+
+            var (_, exitCode) = await this.InvokeAsync(
+                $"-p {Repository.Path} --filter-file-path {solutionPath} -f slnf");
+
+            Assert.Equal(0, exitCode);
+
+            // Load it back through the same model the CLI consumes, so the
+            // test proves the output is usable as input.
+            var filterPath = Path.Combine(Repository.Path, "affected.slnf");
+            var filter = SolutionFilter.LoadFromFile(filterPath);
+
+            Assert.Equal(solutionPath, filter.SolutionPath);
+            Assert.Equal(msBuildProject.FullPath, filter.ProjectPaths.Single());
+        }
+
+        [Fact]
+        public async Task Should_reference_the_solution_relative_to_the_output_dir()
+        {
+            var msBuildProject = this.Repository.CreateCsProject("InventoryManagement");
+            var solutionName = "test-solution.slnx";
+            await this.Repository.CreateXmlSolutionAsync(solutionName, msBuildProject.FullPath);
+
+            var solutionPath = Path.Combine(Repository.Path, solutionName);
+
+            var (_, exitCode) = await this.InvokeAsync(
+                $"-p {Repository.Path} --filter-file-path {solutionPath} -f slnf --output-dir artifacts");
+
+            Assert.Equal(0, exitCode);
+
+            var filterPath = Path.Combine(Repository.Path, "artifacts", "affected.slnf");
+            var contents = await File.ReadAllTextAsync(filterPath);
+
+            // Relative, so that the generated filter can be committed or moved.
+            Assert.DoesNotContain(Repository.Path, contents);
+            Assert.Contains("..", contents);
+
+            // and still resolves back to the real solution.
+            Assert.Equal(solutionPath, SolutionFilter.LoadFromFile(filterPath).SolutionPath);
+        }
+
+        /// <summary>
+        /// The format cannot work without a Solution, and must say so
+        /// instead of failing with a stack trace after building the graph.
+        /// </summary>
+        [Fact]
+        public async Task Without_a_filter_file_should_fail_at_parse_time()
+        {
+            this.Repository.CreateCsProject("InventoryManagement");
+
+            var (_, exitCode) = await this.InvokeAsync($"-p {Repository.Path} --dry-run -f slnf");
+
+            Assert.Equal(AffectedExitCodes.Failure, exitCode);
+
+            var error = Terminal.Error.ToString();
+            Assert.Contains("--filter-file-path", error);
+            Assert.DoesNotContain("   at ", error);
+        }
+
+        [Fact]
+        public async Task Using_a_traversal_project_as_filter_should_fail_at_parse_time()
+        {
+            var msBuildProject = this.Repository.CreateCsProject("InventoryManagement");
+            await this.Repository.CreateTraversalProjectAsync("dirs.proj", msBuildProject.FullPath);
+
+            var traversalPath = Path.Combine(Repository.Path, "dirs.proj");
+
+            var (_, exitCode) = await this.InvokeAsync(
+                $"-p {Repository.Path} --dry-run --filter-file-path {traversalPath} -f slnf");
+
+            Assert.Equal(AffectedExitCodes.Failure, exitCode);
+            Assert.DoesNotContain("   at ", Terminal.Error.ToString());
+        }
+
+        /// <summary>
+        /// --solution-path is the deprecated alias, the validator has to honor it
+        /// or it would reject a perfectly valid invocation.
+        /// </summary>
+        [Fact]
+        public async Task Using_the_obsolete_solution_path_option_should_be_accepted()
+        {
+            var msBuildProject = this.Repository.CreateCsProject("InventoryManagement");
+            var solutionName = "test-solution.slnx";
+            await this.Repository.CreateXmlSolutionAsync(solutionName, msBuildProject.FullPath);
+
+            var solutionPath = Path.Combine(Repository.Path, solutionName);
+
+            var (_, exitCode) = await this.InvokeAsync(
+                $"-p {Repository.Path} --solution-path {solutionPath} -f slnf");
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(solutionPath,
+                SolutionFilter.LoadFromFile(Path.Combine(Repository.Path, "affected.slnf")).SolutionPath);
+        }
+    }
+}


### PR DESCRIPTION
Adds `slnf` output format, narrowing a Solution down to the affected projects so the result can be fed straight to `dotnet test --solution`.

```bash
dotnet affected --filter-file-path Application.slnx --format slnf
dotnet test --solution affected.slnf
```

Builds on `SolutionFilter` (#168) and the formatter context (#169), so the formatter itself is pretty simple.

**Paths are relative to the generated file**, with Windows separators since MSBuild only translates those, so a filter written on Linux stays readable on Windows. 

**slnf requires a Solution to reference**, so in order to ensure it `--filter-file-path` is required. Validated at parse time rather than after building the whole graph.
So you must always provide a `--filter-file-path` in order to use the `slnf` output format.

```
$ dotnet affected -f slnf
The slnf format needs a Solution to reference. Point --filter-file-path at
a Solution (.sln, .slnx) or a Solution Filter (.slnf).
```

Pointing it at an existing `.slnf` narrows that filter; both reference the same Solution.

Closes #148