### PR TITLE
refactor: author traversal projects without evaluating them

### DIFF
--- a/src/DotnetAffected.Core/ProjectDiscovery/MSBuildProjectDiscoverer.cs
+++ b/src/DotnetAffected.Core/ProjectDiscovery/MSBuildProjectDiscoverer.cs
@@ -21,8 +21,8 @@ namespace DotnetAffected.Core
             }
 
             var traversalProjectDirectory = Path.GetDirectoryName(traversalProjectPath);
-            var traversalProject = new Project(traversalProjectPath);
-            
+            var traversalProject = TraversalProject.Load(traversalProjectPath);
+
             return traversalProject
                 .GetItems("ProjectReference")
                 .Select(i => i.EvaluatedInclude)

--- a/src/DotnetAffected.Core/TraversalProject.cs
+++ b/src/DotnetAffected.Core/TraversalProject.cs
@@ -1,0 +1,66 @@
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+using System.IO;
+using System.Xml;
+
+namespace DotnetAffected.Core
+{
+    /// <summary>
+    /// Creates and loads MSBuild Traversal Sdk projects.
+    /// </summary>
+    public static class TraversalProject
+    {
+        /// <summary>
+        /// Name of the MSBuild Sdk used by traversal projects.
+        /// </summary>
+        public const string SdkName = "Microsoft.Build.Traversal";
+
+        /// <summary>
+        /// Version of the <see cref="SdkName"/> Sdk declared by created traversal projects.
+        /// </summary>
+        public const string SdkVersion = "4.1.82";
+
+        /// <summary>
+        /// Creates an empty, in memory traversal project declaring the
+        /// <see cref="SdkName"/>/<see cref="SdkVersion"/> Sdk.
+        /// </summary>
+        /// <remarks>
+        /// REMARKS: The returned project is never evaluated, so the Sdk is never resolved and no NuGet round
+        /// trip takes place. Authoring <c>ProjectReference</c> items and writing out
+        /// <see cref="ProjectRootElement.RawXml"/> are both purely XML operations, so there is nothing to
+        /// evaluate: the Sdk only needs to be named in the output for whoever builds it later.
+        /// </remarks>
+        /// <returns>The traversal project's XML.</returns>
+        public static ProjectRootElement Create()
+        {
+            var projectRootElement = $@"<Project Sdk=""{SdkName}/{SdkVersion}""></Project>";
+
+            using var stringReader = new StringReader(projectRootElement);
+            using var xmlReader = new XmlTextReader(stringReader);
+
+            return ProjectRootElement.Create(xmlReader);
+        }
+
+        /// <summary>
+        /// Loads and evaluates an existing traversal project from disk.
+        /// </summary>
+        /// <remarks>
+        /// REMARKS: Evaluation is required here so that globs, properties and conditions written by whoever
+        /// authored the project resolve. The Traversal Sdk itself is not required: it only attaches metadata
+        /// to <c>ProjectReference</c> items through an ItemDefinitionGroup, and we only read their includes.
+        /// Ignoring missing imports keeps evaluation working when the Sdk cannot be resolved, so that
+        /// discovery does not fail when NuGet is unreachable, slow, or the feed is restricted.
+        /// </remarks>
+        /// <param name="path">Path to the traversal project.</param>
+        /// <returns>The evaluated <see cref="Project"/>.</returns>
+        public static Project Load(string path)
+        {
+            return new Project(
+                path,
+                null,
+                null,
+                ProjectCollection.GlobalProjectCollection,
+                ProjectLoadSettings.IgnoreMissingImports);
+        }
+    }
+}

--- a/src/dotnet-affected/Infrastructure/Formatters/TraversalProjectOutputFormatter.cs
+++ b/src/dotnet-affected/Infrastructure/Formatters/TraversalProjectOutputFormatter.cs
@@ -1,10 +1,7 @@
-﻿using Microsoft.Build.Construction;
-using Microsoft.Build.Evaluation;
+﻿using DotnetAffected.Core;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Xml;
 
 namespace Affected.Cli.Formatters
 {
@@ -15,14 +12,7 @@ namespace Affected.Cli.Formatters
 
         public Task<string> Format(IEnumerable<IProjectInfo> projects, OutputFormatterContext context)
         {
-            var projectRootElement = @"<Project Sdk=""Microsoft.Build.Traversal/4.1.82""></Project>";
-            var stringReader = new StringReader(projectRootElement);
-            var xmlReader = new XmlTextReader(stringReader);
-            var root = ProjectRootElement.Create(xmlReader);
-            
-            // REMARKS: IgnoreMissingImports is required due to the Microsoft.Build.Traversal Sdk not being found
-            // on macos/darwin. We don't really need to evaluate the project, we just need to build the RawXml.
-            var project = new Project(root, null, null, ProjectCollection.GlobalProjectCollection, ProjectLoadSettings.IgnoreMissingImports);
+            var root = TraversalProject.Create();
 
             // Find all affected and add them as project references
             foreach (var projectInfo in projects)
@@ -30,13 +20,13 @@ namespace Affected.Cli.Formatters
                 var currentProjectPath = projectInfo.FilePath;
 
                 // Ignore the current project
-                if (project.Items.All(i => i.EvaluatedInclude != currentProjectPath))
+                if (root.Items.All(i => i.Include != currentProjectPath))
                 {
-                    project.AddItem("ProjectReference", currentProjectPath);
+                    root.AddItem("ProjectReference", currentProjectPath);
                 }
             }
 
-            return Task.FromResult(project.Xml.RawXml);
+            return Task.FromResult(root.RawXml);
         }
     }
 }

--- a/test/DotnetAffected.Testing.Utils/Repository/TemporaryRepositoryExtensions.cs
+++ b/test/DotnetAffected.Testing.Utils/Repository/TemporaryRepositoryExtensions.cs
@@ -194,18 +194,13 @@ namespace DotnetAffected.Testing.Utils
         public static async Task CreateTraversalProjectAsync(
             this TemporaryRepository repo,
             string traversalProjectPath,
-            Action<Project> callback)
+            Action<ProjectRootElement> callback)
         {
-            var projectRootElement = @"<Project Sdk=""Microsoft.Build.Traversal/4.1.82""></Project>";
-            var stringReader = new StringReader(projectRootElement);
-            var xmlReader = new XmlTextReader(stringReader);
-            var root = ProjectRootElement.Create(xmlReader);
-
-            var project = new Project(root);
-            callback.Invoke(project);
+            var root = TraversalProject.Create();
+            callback.Invoke(root);
 
             var finalPath = Path.Combine(repo.Path, traversalProjectPath);
-            var contents = project.Xml.RawXml;
+            var contents = root.RawXml;
 
             await File.WriteAllTextAsync(finalPath, contents);
         }


### PR DESCRIPTION
this fixes the flaky tests.
We don't really need to evaluate the Traversal SDK when generating the proj file.

We do evaluate it when reading.