### PR TITLE
feat: honour gitignore during project discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,18 +69,30 @@ Usage:
 Options:
   -p, --repository-path <repository-path>  Path to the root of the repository, where the .git directory is.
                                            [Defaults to current directory, or solution's directory when using --solution-path]
-  --solution-path <solution-path>          Path to a Solution file (.sln) used to discover projects that may be affected.
+  --solution-path <solution-path>          [OBSOLETE: use --filter-file-path] Path to a Solution file (.sln) used to discover projects that may be affected.
                                            When omitted, will search for project files inside --repository-path.
+  --filter-file-path <filter-file-path>    Path to a filter file (.sln, .slnx, .slnf) used to discover projects that may be affected.
+                                           When omitted, will search for project files inside --repository-path.
+  --no-gitignore                           Discover projects inside paths that git ignores, such as build output or nested clones.
+                                           [Only applies when searching --repository-path, not when using --filter-file-path] [default: False]
   -v, --verbose                            Write useful messages or just the desired output. [default: False]
   --assume-changes <assume-changes>        Hypothetically assume that given projects have changed instead of using Git diff to determine them.
   --from <from>                            A branch or commit to compare against --to.
-  --to <to>                                A branch or commit to compare against --from
-  -f, --format <format>                    Space separated list of formatters to write the output. [default: traversal]
-  --dry-run                                Doesn't create files, outputs to stdout instead. [default: False]
-  --output-dir <output-dir>                The directory where the output file(s) will be generated
-                                           If relative, it's relative to the --repository-path
-  --output-name <output-name>              The name for the file to create for each format.
-                                           Format extension is appended to this name. [default: affected]
+  --to <to>                                A branch or commit to compare against --from.
+  --exclude-output <exclude-output>        A dotnet Regular Expression matched against each project's full path.
+                                           Matching projects are still evaluated, and still carry changes through to
+                                           the projects depending on them, but are kept out of the output.
+  --exclude-discovery <exclude-discovery>  A dotnet Regular Expression matched against each project's full path.
+                                           Matching projects are never loaded, so one that MSBuild cannot evaluate
+                                           stops failing the run. Nothing can depend on them either.
+  -e, --exclude <exclude>                  [OBSOLETE: use --exclude-output] A dotnet Regular Expression used to
+                                           exclude projects from the output.
+  -f, --format <format>                    Space-seperated output file formats. Possible values: <traversal, text, json, slnf>. [default: traversal]
+  --dry-run                                Only output to stdout. No output files will be created. [default: False]
+  --output-dir <output-dir>                The directory where the output file(s) will be generated.
+                                           Relative paths will be based on --repository-path.
+  --output-name <output-name>              The filename to create.
+                                           Format file extensions will be appended. [default: affected]
   --version                                Show version information
   -?, -h, --help                           Show help and usage information
 
@@ -149,6 +161,23 @@ need to specify `--repository-path`. For example:
 ```shell
 dotnet affected --repository-path /home/lchaia/monorepo --solution-path /home/lchaia/monorepo/my-big-project/MyBigProjectSolution.sln
 ```
+
+### Ignored paths
+
+The search honours your `.gitignore`: paths git ignores are not repository content, so build output, tooling scratch
+directories, git worktrees and nested clones are skipped, along with the copies of your projects that live inside them.
+A project that is tracked by git is always discovered, even when a pattern matches it, which is what `git add -f` means.
+
+Pass `--no-gitignore` to search every directory instead, as previous versions did.
+
+```shell
+dotnet affected --no-gitignore
+```
+
+With the MSBuild SDK, set `DotnetAffectedHonourGitIgnore` to `false` for the same effect.
+
+Note this only applies when searching `--repository-path`. Discovery from a Solution or Traversal project uses the
+projects that file lists, ignored or not.
 
 ## Build/test affected projects
 

--- a/src/DotnetAffected.Abstractions/IDiscoveryOptions.cs
+++ b/src/DotnetAffected.Abstractions/IDiscoveryOptions.cs
@@ -17,6 +17,14 @@
         string? FilterFilePath { get; }
 
         /// <summary>
+        /// Gets whether discovery skips paths that git ignores.
+        /// Only applies when discovering from the file system, which is the case when no
+        /// <see cref="FilterFilePath"/> is provided: every other discoverer is handed an
+        /// explicit list of projects.
+        /// </summary>
+        bool HonourGitIgnore { get; }
+
+        /// <summary>
         /// Gets the regular expression matched against the full path of every discovered project,
         /// to keep matching ones out of discovery altogether. They are never handed to MSBuild, so
         /// a project that cannot be evaluated stops taking the whole run down with it.

--- a/src/DotnetAffected.Core/AffectedOptions.cs
+++ b/src/DotnetAffected.Core/AffectedOptions.cs
@@ -21,6 +21,7 @@ namespace DotnetAffected.Core
         /// <param name="exclusionRegex"></param>
         /// <param name="assumeChanges"></param>
         /// <param name="excludeDiscoveryRegex"></param>
+        /// <param name="honourGitIgnore">Defaults to <b>true</b>.</param>
         public AffectedOptions(
             string? repositoryPath = null,
             string? filterFilePath = null,
@@ -28,7 +29,8 @@ namespace DotnetAffected.Core
             string? toRef = null,
             string? exclusionRegex = null,
             IEnumerable<string>? assumeChanges = null,
-            string? excludeDiscoveryRegex = null)
+            string? excludeDiscoveryRegex = null,
+            bool honourGitIgnore = true)
         {
             RepositoryPath = DetermineRepositoryPath(repositoryPath, filterFilePath);
 
@@ -45,6 +47,7 @@ namespace DotnetAffected.Core
             ExclusionRegex = exclusionRegex;
             AssumeChanges = assumeChanges?.ToArray() ?? Array.Empty<string>();
             ExcludeDiscoveryRegex = excludeDiscoveryRegex;
+            HonourGitIgnore = honourGitIgnore;
         }
 
         /// <summary>
@@ -84,6 +87,9 @@ namespace DotnetAffected.Core
         /// Each entry is a path to a project file, a project's ProjectName, or a project file name.
         /// </summary>
         public string[] AssumeChanges { get; }
+
+        /// <inheritdoc />
+        public bool HonourGitIgnore { get; }
 
         private static string DetermineRepositoryPath(string? repositoryPath, string? filterfilePath)
         {

--- a/src/DotnetAffected.Core/ProjectDiscovery/DirectoryProjectDiscoverer.cs
+++ b/src/DotnetAffected.Core/ProjectDiscovery/DirectoryProjectDiscoverer.cs
@@ -1,4 +1,5 @@
 ﻿using DotnetAffected.Abstractions;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,17 +8,84 @@ namespace DotnetAffected.Core
 {
     internal class DirectoryProjectDiscoverer : IProjectDiscoverer
     {
+        private const string GitDirectoryName = ".git";
+
+        private static readonly string[] ProjectFileExtensions =
+        {
+            ".csproj", ".fsproj", ".vbproj"
+        };
+
+        private static readonly StringComparer PathComparer = GitChangesProvider.IsWindows
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+
         public IEnumerable<string> DiscoverProjects(IDiscoveryOptions options)
         {
-            var allowedExtensions = new[]
+            // Trailing separators would make the paths built from the index differ, as strings,
+            // from the ones the walk yields, and the same project would be discovered twice.
+            var rootPath = Path.TrimEndingDirectorySeparator(options.RepositoryPath);
+
+            if (!options.HonourGitIgnore)
+                return EnumerateProjectFiles(rootPath, null)
+                    .ToArray();
+
+            using var filter = GitIgnoreFilter.TryCreate(rootPath);
+            if (filter is null)
+                return EnumerateProjectFiles(rootPath, null)
+                    .ToArray();
+
+            var projects = new HashSet<string>(EnumerateProjectFiles(rootPath, filter), PathComparer);
+
+            // A tracked file is repository content no matter which patterns match it, so
+            // `git add -f build/Tool.csproj` keeps the project discoverable. The walk stopped at
+            // the ignored directory holding it, so the index is what puts it back.
+            foreach (var trackedFile in filter.EnumerateTrackedFiles(IsProjectFile))
             {
-                ".csproj", ".fsproj", ".vbproj"
-            };
-            return Directory
-                .GetFiles(options.RepositoryPath, "*", SearchOption.AllDirectories)
-                .Where(file => allowedExtensions.Any(file.ToLower()
-                    .EndsWith))
-                .ToArray();
+                if (File.Exists(trackedFile))
+                    projects.Add(trackedFile);
+            }
+
+            return projects.ToArray();
         }
+
+        /// <summary>
+        /// Walks <paramref name="rootPath"/>, pruning whole directories rather than filtering the
+        /// files they hold: the ignored ones are where the bulk of a repository's files live, and
+        /// descending into them costs far more than the discovery itself.
+        /// </summary>
+        private static IEnumerable<string> EnumerateProjectFiles(string rootPath, GitIgnoreFilter? filter)
+        {
+            var pendingDirectories = new Queue<string>();
+            pendingDirectories.Enqueue(rootPath);
+
+            while (pendingDirectories.Count > 0)
+            {
+                var directory = pendingDirectories.Dequeue();
+
+                foreach (var file in Directory.EnumerateFiles(directory))
+                {
+                    if (IsProjectFile(file) && filter?.IsIgnored(file, isDirectory: false) != true)
+                        yield return file;
+                }
+
+                foreach (var childDirectory in Directory.EnumerateDirectories(directory))
+                {
+                    // Git does not ignore its own directory, it just never looks at it. Neither
+                    // should we: it holds no projects and, in a packed repository, most of the
+                    // files under the root.
+                    if (string.Equals(Path.GetFileName(childDirectory), GitDirectoryName,
+                            StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    if (filter?.IsIgnored(childDirectory, isDirectory: true) == true)
+                        continue;
+
+                    pendingDirectories.Enqueue(childDirectory);
+                }
+            }
+        }
+
+        private static bool IsProjectFile(string path)
+            => ProjectFileExtensions.Contains(Path.GetExtension(path), StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/DotnetAffected.Core/ProjectDiscovery/GitIgnoreFilter.cs
+++ b/src/DotnetAffected.Core/ProjectDiscovery/GitIgnoreFilter.cs
@@ -1,0 +1,94 @@
+﻿using LibGit2Sharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace DotnetAffected.Core
+{
+    /// <summary>
+    /// Answers whether a path under a repository is ignored by git, so that project discovery
+    /// can leave out what git leaves out.
+    /// </summary>
+    internal sealed class GitIgnoreFilter : IDisposable
+    {
+        private readonly Repository _repository;
+        private readonly string _rootPath;
+
+        private GitIgnoreFilter(Repository repository, string rootPath)
+        {
+            _repository = repository;
+            _rootPath = rootPath;
+        }
+
+        /// <summary>
+        /// Opens the repository rooted at <paramref name="rootPath"/>, or returns <b>null</b>
+        /// when there is no repository there. Discovery is also reachable from places that never
+        /// involve git, such as the benchmarks, and those must keep working.
+        /// </summary>
+        public static GitIgnoreFilter? TryCreate(string rootPath)
+        {
+            try
+            {
+                return new GitIgnoreFilter(new Repository(rootPath), rootPath);
+            }
+            catch (RepositoryNotFoundException)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Whether git ignores <paramref name="path"/>.
+        /// </summary>
+        /// <param name="path">A path under the root this filter was created for.</param>
+        /// <param name="isDirectory">
+        /// Directory patterns such as <c>bin/</c> only match once git knows the path is a
+        /// directory, which is what the trailing separator tells it.
+        /// </param>
+        public bool IsIgnored(string path, bool isDirectory)
+        {
+            var relativePath = ToRepositoryPath(path);
+
+            return _repository.Ignore.IsPathIgnored(isDirectory ? relativePath + "/" : relativePath);
+        }
+
+        /// <summary>
+        /// Full paths of the files in the index whose repository path satisfies
+        /// <paramref name="predicate"/>.
+        /// </summary>
+        public IEnumerable<string> EnumerateTrackedFiles(Func<string, bool> predicate)
+        {
+            foreach (var entry in _repository.Index)
+            {
+                if (!predicate(entry.Path))
+                    continue;
+
+                yield return Path.Combine(_rootPath, ToPlatformPath(entry.Path));
+            }
+        }
+
+        public void Dispose() => _repository.Dispose();
+
+        /// <summary>
+        /// REMARKS: relative to the root we were given, not to
+        /// <see cref="RepositoryInformation.WorkingDirectory"/>. The two differ whenever the
+        /// repository is reached through a symlink, which is the normal case for a temp directory
+        /// on macOS, and git reports the resolved form. Mixing them yields a relative path that
+        /// escapes the working directory, which git considers ignored, and every project would
+        /// silently disappear from discovery.
+        /// </summary>
+        private string ToRepositoryPath(string path)
+        {
+            var relativePath = Path.GetRelativePath(_rootPath, path);
+
+            return GitChangesProvider.IsWindows
+                ? relativePath.Replace('\\', '/')
+                : relativePath;
+        }
+
+        private static string ToPlatformPath(string repositoryPath)
+            => GitChangesProvider.IsWindows
+                ? repositoryPath.Replace('/', Path.DirectorySeparatorChar)
+                : repositoryPath;
+    }
+}

--- a/src/DotnetAffected.Tasks/AffectedTask.cs
+++ b/src/DotnetAffected.Tasks/AffectedTask.cs
@@ -25,6 +25,8 @@ namespace DotnetAffected.Tasks
 
         public ITaskItem[]? FilterClasses { get; set; }
 
+        public bool HonourGitIgnore { get; set; } = true;
+
         [Output] public ITaskItem[] FilterInstances { get; private set; } = null!;
 
         [Output] public string[] ModifiedProjects { get; private set; } = null!;
@@ -43,7 +45,7 @@ namespace DotnetAffected.Tasks
                     .ToArray() ?? Array.Empty<string>();
 
                 var affectedOptions = new AffectedOptions(Root, null, FromRef ?? "", ToRef ?? "",
-                    null, assumeChanges);
+                    null, assumeChanges, honourGitIgnore: HonourGitIgnore);
 
                 if (assumeChanges.Length > 0
                     && (!string.IsNullOrWhiteSpace(affectedOptions.FromRef) ||

--- a/src/DotnetAffected.Tasks/Sdk/Sdk.targets
+++ b/src/DotnetAffected.Tasks/Sdk/Sdk.targets
@@ -13,13 +13,15 @@
 
         <PropertyGroup>
             <DotnetAffectedRoot Condition="'$(DotnetAffectedRoot)' == ''">$(MSBuildStartupDirectory)</DotnetAffectedRoot>
+            <DotnetAffectedHonourGitIgnore Condition="'$(DotnetAffectedHonourGitIgnore)' == ''">true</DotnetAffectedHonourGitIgnore>
         </PropertyGroup>
 
         <DotnetAffected.Tasks.AffectedTask Root="$(DotnetAffectedRoot)"
                                            AssumeChanges="@(DotnetAffectedAssumeChanges)"
                                            FromRef="$(DotnetAffectedFromRef)"
                                            ToRef="$(DotnetAffectedToRef)"
-                                           FilterClasses="@(AffectedFilterClass)">
+                                           FilterClasses="@(AffectedFilterClass)"
+                                           HonourGitIgnore="$(DotnetAffectedHonourGitIgnore)">
             <Output TaskParameter="FilterInstances" ItemName="AffectedFilterInstance" />
             <Output TaskParameter="ModifiedProjects" PropertyName="_ModifiedProjects" />
             <Output TaskParameter="ModifiedProjectsCount" PropertyName="DotnetAffectedProjectCount" />

--- a/src/dotnet-affected/Commands/AffectedGlobalOptions.cs
+++ b/src/dotnet-affected/Commands/AffectedGlobalOptions.cs
@@ -31,6 +31,16 @@ namespace Affected.Cli.Commands
             description: "Path to a filter file (.sln, .slnx, .slnf) used to discover projects that may be affected.\n" +
                          "When omitted, will search for project files inside --repository-path.");
 
+        public static readonly Option<bool> NoGitIgnoreOption = new(
+            aliases: new[]
+            {
+                "--no-gitignore"
+            },
+            getDefaultValue: () => false,
+            description: "Discover projects inside paths that git ignores, such as build output " +
+                         "or nested clones.\n" +
+                         "[Only applies when searching --repository-path, not when using --filter-file-path]");
+
         public static readonly Option<bool> VerboseOption = new(aliases: new[]
             {
                 "--verbose", "-v"

--- a/src/dotnet-affected/Commands/AffectedRootCommand.cs
+++ b/src/dotnet-affected/Commands/AffectedRootCommand.cs
@@ -25,6 +25,7 @@ namespace Affected.Cli.Commands
             this.AddGlobalOption(AffectedGlobalOptions.RepositoryPathOptions);
             this.AddGlobalOption(AffectedGlobalOptions.SolutionPathOption);
             this.AddGlobalOption(AffectedGlobalOptions.FilterFilePathOption);
+            this.AddGlobalOption(AffectedGlobalOptions.NoGitIgnoreOption);
             this.AddGlobalOption(AffectedGlobalOptions.VerboseOption);
             this.AddGlobalOption(AffectedGlobalOptions.AssumeChangesOption);
             this.AddGlobalOption(AffectedGlobalOptions.FromOption);

--- a/src/dotnet-affected/Commands/Binding/AffectedOptionsBinder.cs
+++ b/src/dotnet-affected/Commands/Binding/AffectedOptionsBinder.cs
@@ -36,7 +36,8 @@ namespace Affected.Cli.Commands
                 parseResult.GetValueForOption(AffectedGlobalOptions.ToOption),
                 excludeOutputRegex,
                 parseResult.GetValueForOption(AffectedGlobalOptions.AssumeChangesOption),
-                parseResult.GetValueForOption(AffectedGlobalOptions.ExcludeDiscoveryRegexOption)
+                parseResult.GetValueForOption(AffectedGlobalOptions.ExcludeDiscoveryRegexOption),
+                honourGitIgnore: !parseResult.GetValueForOption(AffectedGlobalOptions.NoGitIgnoreOption)
             );
         }
     }

--- a/test/DotnetAffected.Core.Tests/GitIgnoredProjectDiscoveryTests.cs
+++ b/test/DotnetAffected.Core.Tests/GitIgnoredProjectDiscoveryTests.cs
@@ -1,0 +1,147 @@
+﻿using DotnetAffected.Testing.Utils;
+using LibGit2Sharp;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DotnetAffected.Core.Tests
+{
+    /// <summary>
+    /// Tests for discovering projects from the file system while honouring .gitignore.
+    ///
+    /// Anything git ignores is build output, tooling scratch or a nested clone, none of which is
+    /// a project of this repository. Discovering them means MSBuild evaluates copies of projects
+    /// that are already in the graph under their real path, which at best doubles the work and at
+    /// worst fails the whole run on something that was never meant to be built.
+    ///
+    /// See https://github.com/leonardochaia/dotnet-affected/issues/170
+    /// </summary>
+    public class GitIgnoredProjectDiscoveryTests : BaseRepositoryTest
+    {
+        internal const string ProjectContents = @"<Project Sdk=""Microsoft.NET.Sdk"">
+    <PropertyGroup>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    </PropertyGroup>
+</Project>";
+
+        private string[] DiscoverProjects(bool honourGitIgnore = true)
+            => DiscoverProjects(new AffectedOptions(Repository.Path, honourGitIgnore: honourGitIgnore));
+
+        /// <summary>
+        /// The graph holds a node per target framework, so the paths are deduplicated to get back
+        /// to the set of discovered project files.
+        /// </summary>
+        internal static string[] DiscoverProjects(AffectedOptions options)
+            => new ProjectGraphFactory(options)
+                .BuildProjectGraph()
+                .ProjectNodes
+                .Select(node => node.ProjectInstance.FullPath)
+                .Distinct()
+                .OrderBy(path => path)
+                .ToArray();
+
+        [Fact]
+        public async Task Projects_inside_an_ignored_directory_should_not_be_discovered()
+        {
+            var project = Repository.CreateCsProject("Lib");
+
+            await Repository.CreateTextFileAsync(".gitignore", "artifacts/\n");
+            await Repository.CreateTextFileAsync("artifacts/Lib/Lib.csproj", ProjectContents);
+
+            Assert.Equal(new[] { project.FullPath }, DiscoverProjects());
+        }
+
+        [Fact]
+        public async Task Ignored_project_files_should_not_be_discovered()
+        {
+            var project = Repository.CreateCsProject("Lib");
+
+            // A pattern matching the file itself, rather than the directory holding it.
+            await Repository.CreateTextFileAsync(".gitignore", "Scratch.csproj\n");
+            await Repository.CreateTextFileAsync("scratch/Scratch.csproj", ProjectContents);
+
+            Assert.Equal(new[] { project.FullPath }, DiscoverProjects());
+        }
+
+        [Fact]
+        public async Task Nested_gitignore_files_should_be_honoured()
+        {
+            var project = Repository.CreateCsProject("Lib");
+
+            await Repository.CreateTextFileAsync("src/.gitignore", "generated/\n");
+            await Repository.CreateTextFileAsync("src/generated/Gen/Gen.csproj", ProjectContents);
+
+            Assert.Equal(new[] { project.FullPath }, DiscoverProjects());
+        }
+
+        /// <summary>
+        /// `git add -f` beats the ignore rules: git considers a tracked file to be repository
+        /// content whatever .gitignore says about it, and so must discovery. This is the escape
+        /// hatch for a project that has to live inside an ignored directory.
+        /// </summary>
+        [Fact]
+        public async Task Tracked_projects_should_be_discovered_even_when_a_pattern_matches_them()
+        {
+            var project = Repository.CreateCsProject("Lib");
+
+            await Repository.CreateTextFileAsync(".gitignore", "build/\n");
+            await Repository.CreateTextFileAsync("build/Tool/Tool.csproj", ProjectContents);
+
+            Commands.Stage(Repository.Repository, "build/Tool/Tool.csproj", new StageOptions
+            {
+                IncludeIgnored = true
+            });
+
+            var discovered = DiscoverProjects();
+
+            Assert.Equal(2, discovered.Length);
+            Assert.Contains(project.FullPath, discovered);
+            Assert.Contains(Path.Combine(Repository.Path, "build", "Tool", "Tool.csproj"), discovered);
+        }
+
+        [Fact]
+        public async Task Passing_no_gitignore_should_discover_ignored_projects()
+        {
+            var project = Repository.CreateCsProject("Lib");
+
+            await Repository.CreateTextFileAsync(".gitignore", "artifacts/\n");
+            await Repository.CreateTextFileAsync("artifacts/Copy/Copy.csproj", ProjectContents);
+
+            var discovered = DiscoverProjects(honourGitIgnore: false);
+
+            Assert.Equal(2, discovered.Length);
+            Assert.Contains(project.FullPath, discovered);
+            Assert.Contains(Path.Combine(Repository.Path, "artifacts", "Copy", "Copy.csproj"), discovered);
+        }
+    }
+
+    /// <summary>
+    /// Discovery is reachable without any repository at all, through <see cref="ProjectGraphFactory"/>,
+    /// and must not start requiring one.
+    /// </summary>
+    public class ProjectDiscoveryWithoutGitTests : BaseMSBuildTest
+    {
+        [Fact]
+        public async Task Everything_should_be_discovered_when_the_directory_is_not_a_repository()
+        {
+            using var directory = new TempWorkingDirectory();
+
+            await CreateProjectAsync(directory.Path, Path.Combine("Lib", "Lib.csproj"));
+            await CreateProjectAsync(directory.Path, Path.Combine("bin", "Copy", "Copy.csproj"));
+
+            var discovered = GitIgnoredProjectDiscoveryTests.DiscoverProjects(
+                new AffectedOptions(directory.Path));
+
+            Assert.Equal(2, discovered.Length);
+        }
+
+        private static Task CreateProjectAsync(string root, string relativePath)
+        {
+            var path = Path.Combine(root, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+            return File.WriteAllTextAsync(path, GitIgnoredProjectDiscoveryTests.ProjectContents);
+        }
+    }
+}


### PR DESCRIPTION
Closes #170

## The problem

`DirectoryProjectDiscoverer` walked every directory under `--repository-path`, so build output, tooling scratch directories, git worktrees and nested clones were all searched for projects. Every copy found there became a `ProjectGraph` entry point, which means MSBuild evaluates a project it already holds under its real path — and anything in there that cannot be evaluated takes down the whole run.

`--exclude` does not help: it is applied in `AffectedProcessorBase`, long after the graph has been built.

Measured on this repository, with `--assume-changes DotnetAffected.Core`:

| | projects in output | wall time |
|---|---|---|
| this branch | **8** | 1.3s |
| before (`--no-gitignore`) | **96** | 4.7s |

The 88 extras are copies of this repository's own projects living in `.claude/worktrees/*`. The traversal project would have built other branches' code.

## The change

Discovery now asks git about each directory before descending into it, so ignored trees are never walked, and `.git` is skipped outright. Pruning rather than filtering is where the time goes: ignored directories are where the bulk of a repository's files live.

Two details:

- Directory patterns such as `bin/` only match once git knows the path is a directory, which the trailing separator conveys.
- A tracked file is repository content whatever the patterns say, so `git add -f build/Tool.csproj` keeps the project discoverable. The walk stops at the ignored directory holding it, so the index is what puts it back.

Ignore checks live in a new `GitIgnoreFilter`, which returns `null` when the path is not a repository so that discovery outside git keeps working.

## Opting out

`--no-gitignore` on the CLI, `DotnetAffectedHonourGitIgnore=false` with the MSBuild SDK. Both reach the core as `IDiscoveryOptions.HonourGitIgnore`, added as a default interface member so existing implementations keep compiling.

This only applies to discovery from `--repository-path`. A solution, solution filter or traversal project lists its projects explicitly, ignored or not.

## Tests

Six new tests covering an ignored directory, an ignored file pattern, a nested `.gitignore`, a tracked-but-matched project, `--no-gitignore`, and a directory that is not a repository at all.

All suites pass (Core 112, CLI 45, Tasks 4 on each TFM), and `dotnet build --no-restore --no-incremental /WarnAsError` is clean. Also verified by hand from inside a git worktree, where `.git` is a file rather than a directory.

## Note on behaviour

This changes the default. A repository that deliberately keeps projects inside an ignored path will discover fewer projects after upgrading; `git add -f` on those projects, a `!` rule, or `--no-gitignore` all restore them.
