### PR TITLE
ci: run and publish benchmarks from GitHub Actions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,153 @@
+name: Benchmarks
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      filter:
+        description: 'BenchmarkDotNet --filter glob'
+        default: '*'
+        required: false
+        type: string
+      job:
+        description: 'BenchmarkDotNet --job (dry, short, medium, long, default)'
+        default: 'short'
+        required: false
+        type: string
+
+# Needed to push the results to the benchmark-data branch and to comment on commits.
+permissions:
+  contents: write
+
+# Every run appends to the same files on the data branch, so runs must not overlap.
+concurrency:
+  group: benchmarks
+  cancel-in-progress: false
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: '1'
+  DOTNET_NOLOGO: '1'
+  DOTNET_CLI_TELEMETRY_OPTOUT: '1'
+  NUGET_XMLDOC_MODE: 'skip'
+  DOTNET_MULTILEVEL_LOOKUP: 0
+  CI_BUILD: 'true'
+  BENCHMARK_ARTIFACTS: ${{ github.workspace }}/artifacts/benchmarks
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install .NET
+        run: |
+          ./eng/install-sdk.sh
+          echo "DOTNET_ROOT=$GITHUB_WORKSPACE/eng/.dotnet" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/eng/.dotnet" >> $GITHUB_PATH
+
+      - name: Print host info
+        run: dotnet --info
+
+      # The benchmark project multi-targets. Only the newest TFM is measured, so
+      # building the others would just be CI time spent on nothing.
+      - name: Build
+        run: >
+          dotnet build benchmarks/dotnet-affected.Benchmarks/dotnet-affected.Benchmarks.csproj
+          -c Release -f net10.0
+
+      # --join collapses both benchmark classes into a single report, which is what
+      # the publishing steps below consume.
+      - name: Run benchmarks
+        env:
+          BENCHMARK_FILTER: ${{ inputs.filter || '*' }}
+          BENCHMARK_JOB: ${{ inputs.job || 'short' }}
+        run: >
+          dotnet run -c Release -f net10.0 --no-build
+          --project benchmarks/dotnet-affected.Benchmarks
+          --
+          --filter "$BENCHMARK_FILTER"
+          --job "$BENCHMARK_JOB"
+          --join
+          --exporters json markdown
+          --artifacts "$BENCHMARK_ARTIFACTS"
+
+      # BenchmarkDotNet stamps the run timestamp into the file names.
+      - name: Locate report
+        id: report
+        run: |
+          results="$BENCHMARK_ARTIFACTS/results"
+          echo "json=$(ls "$results"/*-report-full-compressed.json | head -n 1)" >> "$GITHUB_OUTPUT"
+          echo "markdown=$(ls "$results"/*-report-github.md | head -n 1)" >> "$GITHUB_OUTPUT"
+
+      - name: Write job summary
+        run: |
+          {
+            echo "## Benchmark results"
+            echo
+            echo "> Measured on a shared GitHub-hosted runner. Timings are only meaningful"
+            echo "> as a trend against previous runs on the same infrastructure, never as"
+            echo "> absolute numbers. Allocated bytes are deterministic and can be trusted."
+            echo
+            cat "${{ steps.report.outputs.markdown }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # github-action-benchmark's BenchmarkDotNet adapter only reads Statistics.Mean, so
+      # allocations are extracted separately and tracked as their own series.
+      - name: Extract allocations
+        run: |
+          jq '[.Benchmarks[] | {
+                name: .FullName,
+                unit: "bytes",
+                value: .Memory.BytesAllocatedPerOperation
+              }]' "${{ steps.report.outputs.json }}" > "$BENCHMARK_ARTIFACTS/allocations.json"
+
+      - uses: actions/upload-artifact@v4
+        name: 'Upload Benchmark Results'
+        if: always()
+        with:
+          name: benchmark-results
+          path: artifacts/benchmarks/**/*
+
+      # Publishing is skipped for anything but main: forks cannot access the token, and
+      # one point per branch is not a history of anything.
+      #
+      # These write to benchmark-data, which nothing serves. GitHub Pages allows a single
+      # source per repository and the docs site owns it, so the charts this action
+      # generates would never be reachable. The docs build reads the data instead.
+      - name: Publish wall clock
+        if: github.event_name == 'push'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: dotnet-affected (time)
+          tool: benchmarkdotnet
+          output-file-path: ${{ steps.report.outputs.json }}
+          gh-pages-branch: benchmark-data
+          benchmark-data-dir-path: dev/bench/time
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Shared runners drift far enough that anything tighter is all false positives.
+          # See https://blog.martincostello.com/continuous-benchmarks-on-a-budget/
+          alert-threshold: '200%'
+          comment-on-alert: true
+          fail-on-alert: false
+
+      - name: Publish allocations
+        if: github.event_name == 'push'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: dotnet-affected (allocations)
+          tool: customSmallerIsBetter
+          output-file-path: ${{ env.BENCHMARK_ARTIFACTS }}/allocations.json
+          gh-pages-branch: benchmark-data
+          benchmark-data-dir-path: dev/bench/allocations
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Allocated bytes do not vary between runs, so a 5% move is a real move.
+          alert-threshold: '105%'
+          comment-on-alert: true
+          fail-on-alert: true

--- a/README.md
+++ b/README.md
@@ -528,3 +528,17 @@ Or open your favorite ide through the activated command line and it will use the
 source ./eng/activate.sh
 rider Affected.sln
 ```
+
+### Benchmarks
+
+There are BenchmarkDotNet suites covering both the affected detection algorithm and a full
+`dotnet affected` run. They execute on every push to `main` and can be triggered manually from the
+Actions tab, with results recorded on the `benchmark-data` branch and charted on the documentation
+site.
+
+```shell
+dotnet run -c Release -f net10.0 --project benchmarks/dotnet-affected.Benchmarks -- --filter '*' --job short
+```
+
+See [benchmarks/README.md](benchmarks/README.md) for what each suite measures, the regression
+thresholds, and why timings from CI are trends rather than numbers.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,119 @@
+# Benchmarks
+
+[BenchmarkDotNet](https://benchmarkdotnet.org/) suites for dotnet-affected, plus a phase profiler for
+locating hotspots.
+
+## What is measured
+
+| Suite             | Covers                                                                              |
+|-------------------|-------------------------------------------------------------------------------------|
+| `MicroBenchmarks` | The affected detection algorithm only, against a pre-built `ProjectGraph`.            |
+| `MacroBenchmarks` | The full `dotnet affected` invocation: discovery, MSBuild graph construction, git diff, output. |
+
+Both seed a throwaway git repository containing a generated tree of `csproj` files, sized by the
+`TotalProjects` parameter (500 and 1000), and both record allocations via `[MemoryDiagnoser]`.
+
+## Running locally
+
+```bash
+dotnet run -c Release -f net10.0 --project benchmarks/dotnet-affected.Benchmarks -- --filter '*'
+```
+
+`--job short` trades precision for a much faster run, which is what CI uses. The macro suite at 1000
+projects takes tens of seconds *per operation*, so a full default-job run is a long wait.
+
+```bash
+dotnet run -c Release -f net10.0 --project benchmarks/dotnet-affected.Benchmarks -- --filter '*Macro*' --job short
+```
+
+The project also has three non-BenchmarkDotNet modes, which do a single timed pass and print a
+breakdown. Use these to find where time goes, not to measure how much:
+
+```bash
+dotnet run -c Release -f net10.0 --project benchmarks/dotnet-affected.Benchmarks -- profile 250 500 1000
+dotnet run -c Release -f net10.0 --project benchmarks/dotnet-affected.Benchmarks -- graph 500
+dotnet run -c Release -f net10.0 --project benchmarks/dotnet-affected.Benchmarks -- predictors 1000
+```
+
+## Continuous benchmarking
+
+[`.github/workflows/benchmark.yml`](../.github/workflows/benchmark.yml) runs the suites on every push
+to `main`, and on demand via **Actions → Benchmarks → Run workflow** (which takes a `--filter` and a
+`--job` so you can run a single suite without editing the workflow).
+
+Every run:
+
+1. Writes the results table to the workflow's job summary.
+2. Uploads the full BenchmarkDotNet artifacts — JSON, CSV, HTML, markdown — as `benchmark-results`.
+3. On `main` only, pushes two series to the `benchmark-data` branch via
+   [github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark), which
+   compares them against the recorded history and comments on the commit when a threshold is
+   crossed.
+
+### The two series, and why they are separate
+
+**Timings** land in `dev/bench/time` with a 200% alert threshold and do not fail the build. GitHub's
+hosted runners are shared VMs with no guarantee about the underlying hardware, so absolute numbers
+are not comparable between runs and a tight threshold produces nothing but false positives. Treat the
+chart as a trend line: a real regression shows up as a step in the curve, not as a single spike.
+
+**Allocated bytes** land in `dev/bench/allocations` with a 105% threshold and *do* fail the build.
+Allocation counts are deterministic — the same code allocates the same bytes on any machine — so a 5%
+move is a genuine change in behaviour and worth interrupting for. This is the series to watch.
+
+The split exists because github-action-benchmark's BenchmarkDotNet adapter reads only
+`Statistics.Mean`; it ignores `MemoryDiagnoser` output entirely. The workflow extracts allocations
+from the same report with `jq` and feeds them in as a `customSmallerIsBetter` series.
+
+### Where the results live
+
+Results are stored on an orphan `benchmark-data` branch, which nothing serves. GitHub Pages allows
+one source per repository and the documentation site owns it, so the chart pages that
+github-action-benchmark generates alongside the data would never be reachable. They are ignored; the
+data is what matters.
+
+Each series is a single file — `dev/bench/time/data.js` and `dev/bench/allocations/data.js` — holding
+the full run history as one assignment:
+
+```js
+window.BENCHMARK_DATA = { lastUpdate: ..., entries: { ... } }
+```
+
+That history is what the thresholds compare against, and it is also the input the documentation site
+renders. A consumer has to strip the assignment prefix before parsing it as JSON.
+
+### One-time setup
+
+The branch has to exist before the first run:
+
+```bash
+git switch --orphan benchmark-data && git commit --allow-empty -m "chore: initialise benchmark-data" && git push -u origin benchmark-data
+```
+
+The workflow also needs **Settings → Actions → General → Workflow permissions** set to read *and
+write*, so it can push results and comment on commits.
+
+### Publishing to the documentation site
+
+The [Starlight site](../docs) reads these files at build time, checking out `benchmark-data`
+alongside the docs sources and rendering the series with its own components so the charts match the
+site's theme.
+
+There is deliberately no trigger from this workflow to the docs build. Benchmark figures are part of
+what a release advertises, and releases already rebuild the documentation, so the chart is refreshed
+on the cadence that matters. Between releases the published chart lags `main`, while the branch
+itself stays current and keeps gating every merge.
+
+### Cost
+
+A full run is roughly 25–40 minutes on a hosted runner, dominated by the macro suite at 1000
+projects. Runs are serialised through a `benchmarks` concurrency group so they cannot race each other
+onto `benchmark-data`.
+
+## Publishing numbers
+
+If benchmark figures are ever quoted outside of CI — a README table, a blog post, a comparison —
+take them from a run on a known idle machine and publish BenchmarkDotNet's environment header
+alongside them (BenchmarkDotNet version, OS, CPU, SDK, runtime, job configuration). It is emitted at
+the top of every report. A table without it cannot be reproduced or trusted, and CI numbers in
+particular should never be presented as absolute.


### PR DESCRIPTION
Runs the existing BenchmarkDotNet suites in CI and records their history, so performance regressions surface on the PR that causes them instead of being noticed months later.

## What runs

A new `Benchmarks` workflow, on every push to `main` and on demand via **Actions → Benchmarks → Run workflow** (which takes a `--filter` and a `--job`, so a single suite can be run without editing the workflow).

Every run writes the results table to the job summary and uploads the full BenchmarkDotNet artifacts. On `main` it also records two series on an orphan `benchmark-data` branch via [github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark), which compares each run against the recorded history and comments on the commit when a threshold is crossed. The branch is storage only — nothing serves it.

## Two series, two thresholds

| Series | Threshold | Fails build |
|---|---:|---|
| `dev/bench/time` | 200% | no |
| `dev/bench/allocations` | 105% | yes |

Hosted runners are shared VMs with no guarantee about the underlying hardware, so timings are only meaningful as a trend and a tight threshold produces nothing but false positives. Allocated bytes are deterministic, so a small move is a real move and worth interrupting for.

The split is backed by measurement. Across two runs, allocations moved by at most 0.24%, while timings varied by 3.5% standard deviation on an idle laptop:

| Benchmark | Run A | Run B | Delta |
|---|---:|---:|---:|
| Micro 500 | 475.57 MB | 475.57 MB | 0.000% |
| Micro 1000 | 950.97 MB | 951.04 MB | 0.007% |
| Macro 500 | 6028.11 MB | 6042.40 MB | 0.237% |
| Macro 1000 | 13615.60 MB | 13618.34 MB | 0.020% |

The allocations series exists separately because github-action-benchmark's BenchmarkDotNet adapter reads only `Statistics.Mean` and ignores `MemoryDiagnoser` entirely. The workflow extracts `Memory.BytesAllocatedPerOperation` from the same report with `jq` and feeds it in as a `customSmallerIsBetter` series.

## Cost

Roughly 25–40 minutes per run on a hosted runner, dominated by the macro suite at 1000 projects, which takes tens of seconds per operation. CI uses `--job short` for that reason. Runs are serialised through a `benchmarks` concurrency group.

## Verification

The full chain was run locally: `--join` collapsing both suites into one report, `--artifacts` resolving under `--project`, the timestamped filename glob, and the `jq` extraction producing valid output for all four benchmarks. The publish steps only fire on `push` to `main`, so merging is what exercises them.
