### PR TITLE
ci: fix the release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       DOTNET_MULTILEVEL_LOOKUP: 0
       CI_BUILD: 'true'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Install .NET

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,11 @@ on:
         default: "[\"macos-latest\", \"ubuntu-latest\", \"windows-latest\"]"
         required: false
         type: string
+      configuration:
+        description: 'MSBuild configuration to build, test and pack. Releases pass Release'
+        default: 'Debug'
+        required: false
+        type: string
 
 jobs:
   build:
@@ -51,24 +56,24 @@ jobs:
       run: dotnet restore
 
     - name: Build
-      run: dotnet build --no-restore --no-incremental /WarnAsError
+      run: dotnet build --no-restore --no-incremental /WarnAsError -c ${{ inputs.configuration }}
 
     - name: Test
-      run: dotnet test --no-build
+      run: dotnet test --no-build -c ${{ inputs.configuration }}
 
     - name: Run Tool PowerShell
       if: matrix.os == 'windows-latest'
       shell: pwsh
-      run: ./src/dotnet-affected/bin/Debug/net10.0/dotnet-affected -p $Env:GITHUB_WORKSPACE --assume-changes dotnet-affected -v
+      run: ./src/dotnet-affected/bin/${{ inputs.configuration }}/net10.0/dotnet-affected -p $Env:GITHUB_WORKSPACE --assume-changes dotnet-affected -v
 
     - name: Run Tool Bash
       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
       shell: bash
-      run: ./src/dotnet-affected/bin/Debug/net10.0/dotnet-affected -p $GITHUB_WORKSPACE --assume-changes dotnet-affected -v
+      run: ./src/dotnet-affected/bin/${{ inputs.configuration }}/net10.0/dotnet-affected -p $GITHUB_WORKSPACE --assume-changes dotnet-affected -v
 
     - name: Pack
       if: success() && matrix.os == 'ubuntu-latest'
-      run: dotnet pack --no-restore --no-build --configuration Debug --include-symbols -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/packages
+      run: dotnet pack --no-restore --no-build --configuration ${{ inputs.configuration }} --include-symbols -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/packages
 
     - uses: actions/upload-artifact@v4
       name: 'Upload Packages'
@@ -82,4 +87,4 @@ jobs:
       if: success() && matrix.os == 'ubuntu-latest'
       with:
         name: artifacts
-        path: src/dotnet-affected/bin/Debug/net10.0/
+        path: src/dotnet-affected/bin/${{ inputs.configuration }}/net10.0/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,6 @@ on:
     tags:
         - 'v*'
   workflow_dispatch:
-    inputs:
-      skip_affected:
-        description: 'Whether to skip detecting if anything is affected or not'
-        default: false
-        required: false
-        type: boolean
 
 jobs:
   build:
@@ -33,14 +27,6 @@ jobs:
           echo "DOTNET_ROOT=$GITHUB_WORKSPACE/eng/.dotnet" >> $GITHUB_ENV
           echo "$GITHUB_WORKSPACE/eng/.dotnet" >> $GITHUB_PATH
 
-    - uses: nrwl/last-successful-commit-action@v1
-      name: Build Commit Range
-      id: last_successful_commit
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: ${{ github.ref_name }}
-        workflow_id: 'release.yml'
-
     - uses: actions/download-artifact@v4
       name: Download build artifacts
       with:
@@ -49,25 +35,44 @@ jobs:
 
     - name: Detect Affected
       id: affected
-      if: success() && steps.last_successful_commit.outputs.commit_hash != '' && !github.event.inputs.skip_affected
       run: |
+        # The range is the release before this one: the nearest tag reachable from this
+        # commit's parent. What used to stand here asked for the last successful run of
+        # this workflow on ${{ github.ref_name }}, which on a tag push is the tag, so no
+        # run had ever been on it, the lookup came back empty and detection was skipped
+        # on every release it was meant to gate.
+        #
+        # Matched against v* so this agrees with MinVerTagPrefix on what a release tag is.
+        # The repository carries tags that are not releases, and one of those picked up as
+        # the starting point is a wrong answer nothing would report.
+        from=$(git describe --tags --abbrev=0 --match 'v*' "${{ github.sha }}^" 2>/dev/null || true)
+
+        if [ -z "$from" ]; then
+            echo "No earlier tag to compare against. Publishing."
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+            exit 0
+        fi
+
+        echo "Comparing against $from"
+
         set +e
         chmod +x ./dotnet-affected
         # No end ref: the workflow runs with ${{ github.sha }} checked out, and the working
         # directory is what dotnet-affected discovers projects from. --uncommitted none keeps
         # the result depending on the commits alone, whatever earlier steps wrote.
         ./dotnet-affected -p $GITHUB_WORKSPACE -v \
-            --from ${{ steps.last_successful_commit.outputs.commit_hash }} \
+            --from "$from" \
             --uncommitted none \
             --format text
 
         exitCode=$?
+        set -e
 
         if [ $exitCode -eq 0 ]; then
-            echo "::set-output name=should_deploy::true"
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
             echo "Affected projects detected. Will deploy"
         elif [ $exitCode -eq 166 ]; then
-            echo "::set-output name=should_deploy::false"                        
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
             echo "No affected projects detected."
         else
             echo "Failed to run dotnet affected"
@@ -76,11 +81,11 @@ jobs:
 
     - uses: actions/download-artifact@v4
       name: Download Package Artifact
-      if: success() && (steps.affected.outputs.should_deploy == 'true' || github.event.inputs.skip_affected || steps.last_successful_commit.outputs.commit_hash == '')
+      if: steps.affected.outputs.should_deploy == 'true'
       with:
         name: packages
         path: "."
 
     - name: Push to NuGet
-      if: success() && (steps.affected.outputs.should_deploy == 'true' || github.event.inputs.skip_affected || steps.last_successful_commit.outputs.commit_hash == '')
+      if: steps.affected.outputs.should_deploy == 'true'
       run: dotnet nuget push *.nupkg --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       os_matrix: "[\"ubuntu-latest\"]"
+      configuration: 'Release'
 
   release:
     needs: build


### PR DESCRIPTION
`release.yml` has not run against a tag since v6.2.0. Three things in it are broken: one would fail outright on the next run, and two have been silently misbehaving for years.

Behaviour is unchanged in one important respect: affected detection is still a **gate, not a filter**. If anything is affected, all four packages are published — as they must be, since every package is versioned from the same tag and `DotnetAffected.Core` depends on `DotnetAffected.Abstractions` at that exact version.

### `actions/checkout@v4`

`@v2` runs on the retired Node 16 runtime. Bumped in `build.yml` too, since the release builds through it.

### Affected detection now runs on the releases it gates

It never engaged on a tag. `nrwl/last-successful-commit-action` was asked for the last successful run of `release.yml` on `branch: ${{ github.ref_name }}` — on a tag push, that's the tag. No run had ever been on it, so the lookup returned empty, `Detect Affected` was skipped for want of a `commit_hash`, and the empty hash then satisfied the condition guarding the push:

```
commit_hash == ''  ->  Detect Affected skipped
                   ->  push condition includes `commit_hash == ''`  ->  publishes anyway
```

Every tagged release published by falling *through* the gate rather than passing it. Only a manual dispatch from `main` ever ran detection.

The range is now the previous release — the nearest tag reachable from the released commit's parent — which is what a release actually compares against and needs nothing outside git to determine. Restricted to `v*` so it agrees with `MinVerTagPrefix` about what a release tag is; the repository carries tags like `backup-before-amend` that are not releases, and one of those chosen as a starting point is a wrong answer nothing would report.

This drops the archived, `node12` action, and replaces `::set-output` with `$GITHUB_OUTPUT`.

**`skip_affected` is removed.** It never worked either — read as `github.event.inputs.skip_affected`, which is always a string, and `'false'` is truthy in a GitHub expression, so *both* settings skipped detection and deployed. Detection is not optional now.

### Releases are packed in the Release configuration

`build.yml` ran a bare `dotnet build` then packed `--configuration Debug`, and the release job published exactly those artifacts. **Every package on nuget.org from v2 onwards is an unoptimised build with `DEBUG` defined.**

The configuration is now an input defaulted to `Debug`, so PR CI is unchanged, and `release.yml` passes `Release`.

### Verification

No CI run has ever built Release, so it was checked locally:

- solution builds clean in Release under `/WarnAsError` — 0 warnings, 0 errors
- `dotnet pack` produces all four packages plus `.snupkg` symbols
- the tool runs from the parameterised `bin/Release/net10.0/` path

Range resolution against real history:

| tag | resolves to |
|---|---|
| `v6.2.0` | `v6.1.0` |
| `v6.1.0` | `v6.1.0-preview-1` |
| `v6.0.0` | `v6.0.0-preview-1` |
| root commit | *(none — publishes)* |

Both gate outcomes exercised against this repository: exit `0` with changes, exit `166` without.

### Still open

NuGet package metadata is empty — no `Description`, `PackageTags`, `PackageProjectUrl` or `PackageReadmeFile`. `dotnet pack` warns about the missing readme on every package. Separate change.