### PR TITLE
ci: default CI to the Release configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,8 @@ on:
         required: false
         type: string
       configuration:
-        description: 'MSBuild configuration to build, test and pack. Releases pass Release'
-        default: 'Debug'
+        description: 'MSBuild configuration to build, test and pack'
+        default: 'Release'
         required: false
         type: string
 

--- a/test/DotnetAffected.Tasks.Tests/DotnetAffected.Tasks.Tests.csproj
+++ b/test/DotnetAffected.Tasks.Tests/DotnetAffected.Tasks.Tests.csproj
@@ -16,7 +16,12 @@
             <_DotnetAffectedPkgFiles Include="$(MSBuildThisFileDirectory)bin/*DotnetAffected.Tasks.*.snupkg"/>
         </ItemGroup>
         <Delete Files="@(_DotnetAffectedPkgFiles)"/>
-        <Exec Command="dotnet pack -c Release --include-symbols $(SourcesPath)DotnetAffected.Tasks/DotnetAffected.Tasks.csproj -o $(MSBuildThisFileDirectory)bin  -maxcpucount:1"/>
+        <!-- artifacts-path keeps this build's bin and obj to itself. It is a command line global
+             property, so it applies to Tasks and everything it references, and the pack can no
+             longer land in the same output directory as the build that started it. Without it the
+             two write DotnetAffected.Abstractions concurrently whenever the outer build is also
+             Release, and one of them loses the file. -->
+        <Exec Command="dotnet pack -c Release --include-symbols $(SourcesPath)DotnetAffected.Tasks/DotnetAffected.Tasks.csproj -o $(MSBuildThisFileDirectory)bin --artifacts-path $(MSBuildThisFileDirectory)obj/tasks-pack  -maxcpucount:1"/>
     </Target>
 
     <Target Name="_AfterBuild" BeforeTargets="VSTest">


### PR DESCRIPTION
Follow-up to #178, which added the `configuration` input with a `Debug` default.

That left the configuration nobody ships as the only one anybody tests — and a failure that only appears under optimisation would wait for a tag to reveal itself, which is precisely the moment the release workflow is least able to absorb one.

There is nothing to trade away for it. The codebase has no `#if DEBUG`, no `Debug.Assert` and no MSBuild condition on `$(Configuration)`, so the two differ only in optimisation and the `DEBUG` symbol.

The default flips to `Release`. The input stays, so a caller that wants `Debug` can still ask for it.

### The second commit: a race the split was hiding

Flipping the default broke `ubuntu-latest` immediately, and that turned out to be worth knowing.

`DotnetAffected.Tasks.Tests` packs the Tasks SDK during its own build, so the tests consume it as a package rather than as build output. That `Exec` hardcodes `-c Release`. While the outer build was `Debug` the two wrote to `bin/Debug` and `bin/Release` and never met — but once both are `Release` they share an output directory, and the nested pack and the outer build write `DotnetAffected.Abstractions` concurrently:

```
error MSB4018: System.IO.IOException: The process cannot access the file
'.../DotnetAffected.Abstractions/bin/Release/net8.0/DotnetAffected.Abstractions.deps.json'
because it is being used by another process.
```

Being a race, it is not consistent about it: it failed on `ubuntu-latest` and passed on macOS and Windows **in the same run**, and passes locally.

`--artifacts-path` gives the nested build its own `bin` and `obj`. As a command-line global property it covers `Tasks` and everything it references, which is what the collision was actually about. `-o` is explicit and unaffected, so the package still lands where the test project globs for it.

The comment already at the top of that target warned about locks and races. The configuration split had been quietly holding this one off — it would bite anyone running `dotnet build -c Release` locally today.

### Verification

Structural rather than "it passed once", since a race can pass by luck:

- deleted `src/DotnetAffected.Abstractions/bin/Release`, ran the `Exec`'s command alone — it no longer recreates that directory; the `deps.json` lands in `obj/tasks-pack` instead
- the `.nupkg` and `.snupkg` still land in the test project's `bin`
- Release build clean under `/WarnAsError`, Tasks tests pass on net8.0, net9.0 and net10.0

And CI is green on all three operating systems, with `ubuntu-latest` now doing a full Release build and test run.