### PR TITLE
chore: give the packages the metadata a listing is made of

### DIFF
--- a/package-defaults.props
+++ b/package-defaults.props
@@ -12,6 +12,10 @@
              one sentence cannot introduce all of them. -->
         <PackageProjectUrl>https://dotnet-affected.com</PackageProjectUrl>
         <PackageTags>msbuild;monorepo;affected;incremental-build;ci;continuous-integration;git;dotnet-tool</PackageTags>
+
+        <!-- The readme packed into the package. A project with a readme of its own sets
+             PackageReadmeSource above its import of this file. -->
+        <PackageReadmeSource Condition="'$(PackageReadmeSource)' == ''">$(MSBuildThisFileDirectory)README.md</PackageReadmeSource>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <Copyright>Copyright (c) Leonardo Chaia</Copyright>
 
@@ -32,9 +36,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <!-- PackageReadmeFile names a file inside the package, so the repository readme has to be put
-             there. MSBuildThisFileDirectory is the repository root, which is where this props file lives. -->
-        <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" Visible="false"/>
+        <!-- PackageReadmeFile names a file inside the package, so the readme has to be put there. -->
+        <None Include="$(PackageReadmeSource)" Pack="true" PackagePath="\" Visible="false"/>
     </ItemGroup>
 
     <ItemGroup Condition=" '$(ContinuousIntegrationBuild)' == 'true'">

--- a/package-defaults.props
+++ b/package-defaults.props
@@ -8,6 +8,13 @@
         <Title>$(AssemblyTitle)</Title>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
+        <!-- Shown on the listing page. Description is per package: these four do different things and
+             one sentence cannot introduce all of them. -->
+        <PackageProjectUrl>https://dotnet-affected.com</PackageProjectUrl>
+        <PackageTags>msbuild;monorepo;affected;incremental-build;ci;continuous-integration;git;dotnet-tool</PackageTags>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <Copyright>Copyright (c) Leonardo Chaia</Copyright>
+
         <RepositoryUrl>https://github.com/leonardochaia/dotnet-affected.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -22,6 +29,12 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="MinVer" PrivateAssets="All"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <!-- PackageReadmeFile names a file inside the package, so the repository readme has to be put
+             there. MSBuildThisFileDirectory is the repository root, which is where this props file lives. -->
+        <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" Visible="false"/>
     </ItemGroup>
 
     <ItemGroup Condition=" '$(ContinuousIntegrationBuild)' == 'true'">

--- a/src/DotnetAffected.Abstractions/DotnetAffected.Abstractions.csproj
+++ b/src/DotnetAffected.Abstractions/DotnetAffected.Abstractions.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="$(PackageDefaultsPropsPath)" />
 
+    <PropertyGroup>
+        <Description>The interfaces and option types the dotnet-affected packages are written against. Reference this to supply your own changes provider or output formatter without taking a dependency on the implementation.</Description>
+    </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
     </ItemGroup>

--- a/src/DotnetAffected.Core/DotnetAffected.Core.csproj
+++ b/src/DotnetAffected.Core/DotnetAffected.Core.csproj
@@ -3,6 +3,8 @@
 
     <PropertyGroup>
         <RootNamespace>DotnetAffected.Core</RootNamespace>
+
+        <Description>The implementation behind the dotnet-affected CLI: reading changes from git, discovering and evaluating projects, and traversing the MSBuild project graph to find what a change affects. Reference this to determine affected projects from your own code rather than through the command line.</Description>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="$(SourcesPath)/DotnetAffected.Abstractions/DotnetAffected.Abstractions.csproj" />

--- a/src/DotnetAffected.Tasks/DotnetAffected.Tasks.csproj
+++ b/src/DotnetAffected.Tasks/DotnetAffected.Tasks.csproj
@@ -5,6 +5,8 @@
     <PropertyGroup>
         <RootNamespace>DotnetAffected.Tasks</RootNamespace>
 
+        <Description>An MSBuild project SDK that builds only the projects a set of changes affects, for repositories that drive CI from MSBuild rather than from a command line. Filters the project tree and hands execution to Microsoft.Build.Traversal. The SDK version tracks the dotnet-affected version.</Description>
+
         <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
 
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/DotnetAffected.Tasks/DotnetAffected.Tasks.csproj
+++ b/src/DotnetAffected.Tasks/DotnetAffected.Tasks.csproj
@@ -1,5 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <PropertyGroup>
+        <!-- Set above the import, which defaults this to the repository readme: properties are
+             evaluated in order and the import consumes it. This SDK has a readme of its own, and it
+             is the one that answers what somebody looking at this package is asking. -->
+        <PackageReadmeSource>$(MSBuildThisFileDirectory)README.md</PackageReadmeSource>
+    </PropertyGroup>
+
     <Import Project="$(PackageDefaultsPropsPath)" />
 
     <PropertyGroup>

--- a/src/dotnet-affected/dotnet-affected.csproj
+++ b/src/dotnet-affected/dotnet-affected.csproj
@@ -6,6 +6,8 @@
         <OutputType>Exe</OutputType>
         <ToolCommandName>dotnet-affected</ToolCommandName>
         <PackAsTool>true</PackAsTool>
+
+        <Description>A .NET CLI tool that works out which MSBuild projects a set of changes affects, so large repositories and monorepos can build and test a fraction of themselves instead of all of it. Compares the working tree against a baseline commit, maps changed files to the projects that own them, and walks the project graph for everything depending on those.</Description>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
None of the four packages set `Description`, `PackageProjectUrl`, `PackageTags`, `PackageReadmeFile` or `Copyright`, so they arrive on nuget.org as a title and a version — and `dotnet pack` warned about the missing readme on every run:

```
The package DotnetAffected.Tasks.6.2.1-preview.0.22 is missing a readme.
```

**This has to land before the tag, not after.** Metadata is written into the `.nupkg` at pack time; a package that has already been pushed cannot be given a description.

### Description is per project

The four packages answer different questions — a CLI tool, the implementation behind it, the interfaces it is written against, and an MSBuild SDK — so a single shared sentence would be wrong for at least three of them. Everything genuinely shared (`PackageProjectUrl`, `PackageTags`, `Copyright`) stays in `package-defaults.props`.

### So is the readme

`PackageReadmeFile` names a file *inside* the package, so a readme has to be packed into each one. Three of them get the repository readme. `DotnetAffected.Tasks` gets its own: somebody looking at that package has already decided against the CLI, and reading about installing a dotnet tool answers nothing they asked.

`PackageReadmeSource` defaults to the repository readme; the SDK sets its own. It has to be set *above* the import — properties evaluate in order and the import is what consumes it — which is called out in a comment there.

### Verification

Packed all four and read the generated nuspecs and package contents:

| package | readme packed | projectUrl | tags | own description |
|---|---|---|---|---|
| `dotnet-affected` | root | ✅ | ✅ | ✅ |
| `DotnetAffected.Core` | root | ✅ | ✅ | ✅ |
| `DotnetAffected.Abstractions` | root | ✅ | ✅ | ✅ |
| `DotnetAffected.Tasks` | **its own** | ✅ | ✅ | ✅ |

Each package contains exactly one `README.md` — the override replaces the default rather than adding to it — and pack no longer warns.

### The readmes improve when #180 lands

No change needed here, they just get better:

- the root readme becomes an 82-line landing page with install and usage, instead of the 26KB reference
- the Tasks readme becomes a 23-line page pointing at `dotnet-affected.com/msbuild-sdk/`, already using `DotnetAffected.Tasks/7.0.0`

### One thing to know

**`PackageProjectUrl` points at `https://dotnet-affected.com`,** which is not serving yet. It needs DNS and the Pages source configured before `v7.0.0` is tagged, or every listing links somewhere dead.

### Not included

`PackageIcon` — there is no logo anywhere in the repository, and inventing one is not this PR's job.