### PR TITLE
docs: add Umami Cloud analytics to the docs site

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -30,6 +30,16 @@ export default defineConfig({
 			editLink: {
 				baseUrl: 'https://github.com/leonardochaia/dotnet-affected/edit/main/docs/',
 			},
+			head: [
+				{
+					tag: 'script',
+					attrs: {
+						defer: true,
+						src: 'https://cloud.umami.is/script.js',
+						'data-website-id': '04603e4d-e6d4-43f8-a2d5-da4072c3e72f',
+					},
+				},
+			],
 			plugins: [starlightLinksValidator()],
 			sidebar: [
 				{


### PR DESCRIPTION
Adds the Umami Cloud tracking script to dotnet-affected.com.

Injected on every Starlight page via the `head` option in `docs/astro.config.mjs`:

```html
<script defer src="https://cloud.umami.is/script.js" data-website-id="04603e4d-e6d4-43f8-a2d5-da4072c3e72f"></script>
```

Note: the script also loads under `astro dev` / `astro preview`, so local page views will land in the same Umami site. If that's not wanted, `data-domains="dotnet-affected.com"` can be added to restrict reporting to the production host.