### PR TITLE
ci: publish to NuGet via trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,12 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      # Declaring any permission drops the rest to none, so contents has to be
+      # spelled out for actions/checkout. id-token is what lets the job request
+      # the OIDC token that NuGet trusted publishing exchanges for an API key.
+      contents: read
+      id-token: write
     steps:
     - uses: actions/checkout@v4
       with:
@@ -86,6 +92,15 @@ jobs:
         name: packages
         path: "."
 
+    # The key this hands back lives for an hour and is good for a single push, so
+    # it is requested here, last, rather than at the top of the job.
+    - name: NuGet login (OIDC -> temporary API key)
+      id: nuget-login
+      if: steps.affected.outputs.should_deploy == 'true'
+      uses: NuGet/login@v1
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     - name: Push to NuGet
       if: steps.affected.outputs.should_deploy == 'true'
-      run: dotnet nuget push *.nupkg --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}
+      run: dotnet nuget push *.nupkg --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{ steps.nuget-login.outputs.NUGET_API_KEY }}


### PR DESCRIPTION
Swaps the long-lived `NUGET_API_KEY` secret in the release workflow for [NuGet trusted publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing#github-actions-setup): the job requests an OIDC token from GitHub, `NuGet/login` exchanges it with nuget.org for an API key good for one hour and a single push, and the push uses that.

### Changes

- `release` job gains `permissions: id-token: write`. Declaring any permission drops the rest to `none`, so `contents: read` is spelled out too, otherwise `actions/checkout` breaks.
- A `NuGet/login@v1` step sits immediately before the push, behind the same `should_deploy` gate. Placement is deliberate: the key expires in an hour, so requesting it at the top of the job would risk it going stale behind the affected-detection and artifact-download steps.
