### PR TITLE
docs: publish the v6 to v7 performance comparison

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -88,6 +88,7 @@ export default defineConfig({
 					items: [
 						{ label: 'CLI', slug: 'reference/cli' },
 						{ label: 'Exit codes', slug: 'reference/exit-codes' },
+						{ label: 'Performance', slug: 'performance' },
 					],
 				},
 				{

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -40,6 +40,7 @@ export default defineConfig({
 					},
 				},
 			],
+			customCss: ['./src/styles/layout.css'],
 			plugins: [starlightLinksValidator()],
 			sidebar: [
 				{

--- a/docs/src/components/BenchmarkCharts.astro
+++ b/docs/src/components/BenchmarkCharts.astro
@@ -1,0 +1,360 @@
+---
+/**
+ * The two charts for a benchmark comparison, rendered to SVG at build time.
+ *
+ * Colours come from the data-viz palette, validated against this site's surfaces
+ * (#ffffff light, #17181c dark): the dumbbell is one hue at two steps — an ordinal
+ * pair, since the two ends are the same measure before and after — and the speedup
+ * bars are a single series, so they carry no legend.
+ */
+import type { BenchmarkComparison } from '../lib/benchmarks';
+import { formatProjects, formatSeconds, formatSpeedup } from '../lib/benchmarks';
+
+interface Props {
+	data: BenchmarkComparison;
+}
+
+const { data } = Astro.props;
+const rows = [...data.measurements].sort((a, b) => a.totalProjects - b.totalProjects);
+const baselineRef = data.comparison.baseline.ref;
+
+// --- dumbbell: wall clock, log axis ------------------------------------------
+// Log because the sizes span two orders of magnitude. It encodes position, not
+// length, so the scale has no zero to be honest about.
+const allSeconds = rows.flatMap(r => [r.baseline.meanSeconds, r.candidate.meanSeconds]);
+const decadeFloor = Math.floor(Math.log10(Math.min(...allSeconds)));
+const decadeCeil = Math.ceil(Math.log10(Math.max(...allSeconds)));
+const ticks = Array.from({ length: decadeCeil - decadeFloor + 1 }, (_, i) =>
+	Math.pow(10, decadeFloor + i),
+);
+
+const dumbbell = { width: 720, rowHeight: 54, top: 34, bottom: 44, left: 96, right: 78 };
+const dumbbellHeight = dumbbell.top + rows.length * dumbbell.rowHeight + dumbbell.bottom;
+const plotWidth = dumbbell.width - dumbbell.left - dumbbell.right;
+
+const xOf = (seconds: number) =>
+	dumbbell.left +
+	((Math.log10(seconds) - decadeFloor) / (decadeCeil - decadeFloor)) * plotWidth;
+const yOf = (index: number) => dumbbell.top + index * dumbbell.rowHeight + dumbbell.rowHeight / 2;
+
+// --- bars: speedup ------------------------------------------------------------
+const bars = { width: 720, rowHeight: 44, top: 24, bottom: 40, left: 96, right: 78 };
+const barsHeight = bars.top + rows.length * bars.rowHeight + bars.bottom;
+const barsPlotWidth = bars.width - bars.left - bars.right;
+const maxSpeedup = Math.max(...rows.map(r => r.speedup));
+// Zero based, and rounded up to a whole multiple so ticks land on integers. Bars
+// encode length, so the axis has to start at nothing: anchoring them at 1x would
+// stretch a 4.9x difference in the data into a 17x difference on screen.
+const speedupMax = Math.ceil(maxSpeedup);
+const speedupTicks = Array.from({ length: speedupMax + 1 }, (_, i) => i);
+const xSpeedup = (speedup: number) => bars.left + (speedup / speedupMax) * barsPlotWidth;
+const barWidth = (speedup: number) => (speedup / speedupMax) * barsPlotWidth;
+const barX = (speedup: number) => bars.left + barWidth(speedup);
+/** Square at the baseline, 4px rounded at the data end. */
+const barPath = (speedup: number, y: number) => {
+	const w = Math.max(barWidth(speedup), 5);
+	const r = Math.min(4, w);
+	return `M ${bars.left} ${y - 9} H ${bars.left + w - r} a ${r} ${r} 0 0 1 ${r} ${r} V ${y + 9 - r} a ${r} ${r} 0 0 1 ${-r} ${r} H ${bars.left} Z`;
+};
+---
+
+<div class="viz-root">
+	<figure class="viz-figure">
+		<figcaption>
+			<strong>How much faster</strong>
+			<span>Speedup over {baselineRef}, by repository size. Higher is better.</span>
+		</figcaption>
+		<svg
+			viewBox={`0 0 ${bars.width} ${barsHeight}`}
+			role="img"
+			aria-label={`Speedup over ${baselineRef} by repository size, from ${formatSpeedup(rows[0].speedup)} at ${formatProjects(rows[0].totalProjects)} projects to ${formatSpeedup(rows[rows.length - 1].speedup)} at ${formatProjects(rows[rows.length - 1].totalProjects)} projects.`}
+		>
+			{
+				speedupTicks.map(tick => (
+					<g>
+						<line
+							class="grid"
+							x1={xSpeedup(tick)}
+							x2={xSpeedup(tick)}
+							y1={bars.top}
+							y2={barsHeight - bars.bottom + 6}
+						/>
+						<text class="tick" x={xSpeedup(tick)} y={barsHeight - bars.bottom + 22} text-anchor="middle"
+							>{tick}×</text
+						>
+					</g>
+				))
+			}
+			{
+				rows.map((row, i) => {
+					const y = bars.top + i * bars.rowHeight + bars.rowHeight / 2;
+					return (
+						<g>
+							<title>
+								{formatProjects(row.totalProjects)} projects: {formatSpeedup(row.speedup)} faster (
+								{formatSeconds(row.baseline.meanSeconds)} → {formatSeconds(row.candidate.meanSeconds)})
+							</title>
+							<text class="row-label" x={bars.left - 14} y={y + 4} text-anchor="end">
+								{formatProjects(row.totalProjects)}
+							</text>
+							<rect
+								class="bar"
+								x={bars.left}
+								y={y - 9}
+								width={Math.max(barWidth(row.speedup), 0.5)}
+								height={18}
+								rx="4"
+							/>
+							<text class="value" x={barX(row.speedup) + 10} y={y + 4}>{formatSpeedup(row.speedup)}</text>
+						</g>
+					);
+				})
+			}
+			<line
+				class="reference"
+				x1={xSpeedup(1)}
+				x2={xSpeedup(1)}
+				y1={bars.top}
+				y2={barsHeight - bars.bottom}></line>
+			<text class="reference-label" x={xSpeedup(1) + 6} y={bars.top + 10}>no change</text>
+			<line
+				class="axis"
+				x1={bars.left}
+				x2={bars.left}
+				y1={bars.top}
+				y2={barsHeight - bars.bottom + 6}></line>
+		</svg>
+	</figure>
+
+	<figure class="viz-figure">
+		<figcaption>
+			<strong>Wall clock per run</strong>
+			<span>
+				Mean of the measured iterations. The axis is logarithmic — each gridline is ten times
+				the last.
+			</span>
+		</figcaption>
+		<svg
+			viewBox={`0 0 ${dumbbell.width} ${dumbbellHeight}`}
+			role="img"
+			aria-label={`Wall clock per run at ${baselineRef} against the candidate, for each repository size. The gap widens with size.`}
+		>
+			<g class="legend">
+				<circle class="dot-baseline" cx={dumbbell.left} cy="14" r="6"></circle>
+				<text class="legend-text" x={dumbbell.left + 13} y="18">{baselineRef}</text>
+				<circle class="dot-candidate" cx={dumbbell.left + 92} cy="14" r="6"></circle>
+				<text class="legend-text" x={dumbbell.left + 105} y="18">v7</text>
+			</g>
+			{
+				ticks.map(tick => (
+					<g>
+						<line
+							class="grid"
+							x1={xOf(tick)}
+							x2={xOf(tick)}
+							y1={dumbbell.top}
+							y2={dumbbellHeight - dumbbell.bottom + 6}
+						/>
+						<text
+							class="tick"
+							x={xOf(tick)}
+							y={dumbbellHeight - dumbbell.bottom + 22}
+							text-anchor="middle">{tick < 1 ? tick : `${tick}s`}</text
+						>
+					</g>
+				))
+			}
+			{
+				rows.map((row, i) => {
+					const y = yOf(i);
+					return (
+						<g>
+							<title>
+								{formatProjects(row.totalProjects)} projects: {baselineRef}{' '}
+								{formatSeconds(row.baseline.meanSeconds)}, v7{' '}
+								{formatSeconds(row.candidate.meanSeconds)} ({formatSpeedup(row.speedup)} faster)
+							</title>
+							<text class="row-label" x={dumbbell.left - 14} y={y + 4} text-anchor="end">
+								{formatProjects(row.totalProjects)}
+							</text>
+							<line
+								class="connector"
+								x1={xOf(row.candidate.meanSeconds)}
+								x2={xOf(row.baseline.meanSeconds)}
+								y1={y}
+								y2={y}
+							/>
+							<circle
+								class="dot-baseline"
+								cx={xOf(row.baseline.meanSeconds)}
+								cy={y}
+								r="7"
+							/>
+							<circle
+								class="dot-candidate"
+								cx={xOf(row.candidate.meanSeconds)}
+								cy={y}
+								r="7"
+							/>
+							<text class="value" x={xOf(row.baseline.meanSeconds) + 14} y={y + 4}>
+								{formatSeconds(row.baseline.meanSeconds)}
+							</text>
+						</g>
+					);
+				})
+			}
+			<line
+				class="axis"
+				x1={dumbbell.left}
+				x2={dumbbell.left}
+				y1={dumbbell.top}
+				y2={dumbbellHeight - dumbbell.bottom + 6}></line>
+		</svg>
+		<p class="viz-note">
+			Row labels are total projects. Exact numbers, spread and iteration counts are in the
+			table below.
+		</p>
+	</figure>
+</div>
+
+<style>
+	.viz-root {
+		/* Validated against this site's surfaces: #ffffff light, #17181c dark. */
+		--surface: #ffffff;
+		--series-strong: #2a78d6;
+		--series-soft: #86b6ef;
+		--ink-primary: #0b0b0b;
+		--ink-secondary: #52514e;
+		--ink-muted: #898781;
+		--grid: #e1e0d9;
+		--axis: #c3c2b7;
+	}
+
+	@media (prefers-color-scheme: dark) {
+		:root:where(:not([data-theme='light'])) .viz-root {
+			--surface: #17181c;
+			--series-strong: #3987e5;
+			--series-soft: #184f95;
+			--ink-primary: #ffffff;
+			--ink-secondary: #c3c2b7;
+			--grid: #2c2c2a;
+			--axis: #383835;
+		}
+	}
+
+	:root[data-theme='dark'] .viz-root {
+		--surface: #17181c;
+		--series-strong: #3987e5;
+		--series-soft: #184f95;
+		--ink-primary: #ffffff;
+		--ink-secondary: #c3c2b7;
+		--grid: #2c2c2a;
+		--axis: #383835;
+	}
+
+	.viz-figure {
+		margin: 1.75rem 0;
+	}
+
+	.viz-figure figcaption {
+		display: flex;
+		flex-direction: column;
+		gap: 0.15rem;
+		margin-bottom: 0.5rem;
+	}
+
+	.viz-figure figcaption strong {
+		color: var(--ink-primary);
+		font-size: var(--sl-text-lg);
+	}
+
+	.viz-figure figcaption span,
+	.viz-note {
+		color: var(--ink-secondary);
+		font-size: var(--sl-text-sm);
+	}
+
+	.viz-note {
+		margin: 0.4rem 0 0;
+	}
+
+	svg {
+		display: block;
+		width: 100%;
+		height: auto;
+		overflow: visible;
+		font-family: var(--sl-font-system, system-ui, sans-serif);
+	}
+
+	.grid {
+		stroke: var(--grid);
+		stroke-width: 1;
+	}
+
+	.axis {
+		stroke: var(--axis);
+		stroke-width: 1;
+	}
+
+	.tick {
+		fill: var(--ink-muted);
+		font-size: 12px;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.row-label {
+		fill: var(--ink-secondary);
+		font-size: 13px;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.value {
+		fill: var(--ink-primary);
+		font-size: 13px;
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.legend-text {
+		fill: var(--ink-secondary);
+		font-size: 12px;
+	}
+
+	.bar {
+		fill: var(--series-strong);
+	}
+
+	.reference {
+		stroke: var(--axis);
+		stroke-width: 1;
+		stroke-dasharray: 3 3;
+	}
+
+	.reference-label {
+		fill: var(--ink-muted);
+		font-size: 11px;
+	}
+
+	.connector {
+		stroke: var(--series-soft);
+		stroke-width: 2;
+	}
+
+	.dot-baseline {
+		fill: var(--series-soft);
+	}
+
+	.dot-candidate {
+		fill: var(--series-strong);
+		/* 2px surface ring, so overlapping marks stay separable. */
+		stroke: var(--surface);
+		stroke-width: 2;
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		.bar,
+		.dot-candidate {
+			transition: none;
+		}
+	}
+</style>

--- a/docs/src/components/BenchmarkCharts.astro
+++ b/docs/src/components/BenchmarkCharts.astro
@@ -97,14 +97,7 @@ const barPath = (speedup: number, y: number) => {
 							<text class="row-label" x={bars.left - 14} y={y + 4} text-anchor="end">
 								{formatProjects(row.totalProjects)}
 							</text>
-							<rect
-								class="bar"
-								x={bars.left}
-								y={y - 9}
-								width={Math.max(barWidth(row.speedup), 0.5)}
-								height={18}
-								rx="4"
-							/>
+							<path class="bar" d={barPath(row.speedup, y)} />
 							<text class="value" x={barX(row.speedup) + 10} y={y + 4}>{formatSpeedup(row.speedup)}</text>
 						</g>
 					);

--- a/docs/src/components/BenchmarkHero.astro
+++ b/docs/src/components/BenchmarkHero.astro
@@ -2,6 +2,11 @@
 /**
  * The headline figure for a comparison.
  *
+ * The number states what it is faster *than* and at what size, in the label above
+ * it: a bare "6.5x faster" reads as a blanket claim, and it is the best of the four
+ * sizes measured, not the general case. The caption gives the absolute times and the
+ * smallest size, so the range is visible without scrolling.
+ *
  * A component rather than markup in the page: MDX wraps text inside JSX in a
  * paragraph, and a paragraph inside the caption span is invalid nesting that the
  * browser hoists apart, leaving the caption empty in the DOM.
@@ -15,28 +20,44 @@ interface Props {
 
 const { data } = Astro.props;
 const top = headline(data);
+const smallest = [...data.measurements].sort((a, b) => a.totalProjects - b.totalProjects)[0];
 const baselineRef = data.comparison.baseline.ref;
 ---
 
 <div class="hero-figure">
-	<div class="hero-value">{formatSpeedup(top.speedup)} faster</div>
-	<div class="hero-caption">
-		on a {formatProjects(top.totalProjects)}-project repository — {
-			formatSeconds(top.baseline.meanSeconds)
-		} at {baselineRef} against {formatSeconds(top.candidate.meanSeconds)} at v7
-	</div>
+	<p class="hero-label">
+		v7 against {baselineRef}, on a {formatProjects(top.totalProjects)}-project repository
+	</p>
+	<p class="hero-value">{formatSpeedup(top.speedup)} faster</p>
+	<p class="hero-caption">
+		{formatSeconds(top.baseline.meanSeconds)} at {baselineRef} against {
+			formatSeconds(top.candidate.meanSeconds)
+		} at v7. At {formatProjects(smallest.totalProjects)} projects it is {
+			formatSpeedup(smallest.speedup)
+		} — the gap widens with repository size.
+	</p>
 </div>
 
 <style>
 	.hero-figure {
 		display: flex;
 		flex-direction: column;
-		gap: 0.35rem;
+		gap: 0.3rem;
 		margin: 1.5rem 0 1.75rem;
 	}
 
+	.hero-figure p {
+		margin: 0;
+	}
+
+	.hero-label {
+		color: var(--sl-color-gray-2);
+		font-size: var(--sl-text-sm);
+		text-transform: none;
+	}
+
 	.hero-value {
-		font-size: clamp(2.5rem, 8vw, 3.5rem);
+		font-size: clamp(2.25rem, 7vw, 3.25rem);
 		font-weight: 700;
 		line-height: 1.05;
 		color: var(--sl-color-white);
@@ -45,6 +66,6 @@ const baselineRef = data.comparison.baseline.ref;
 	.hero-caption {
 		color: var(--sl-color-gray-2);
 		font-size: var(--sl-text-base);
-		max-width: 52ch;
+		max-width: 56ch;
 	}
 </style>

--- a/docs/src/components/BenchmarkHero.astro
+++ b/docs/src/components/BenchmarkHero.astro
@@ -1,0 +1,50 @@
+---
+/**
+ * The headline figure for a comparison.
+ *
+ * A component rather than markup in the page: MDX wraps text inside JSX in a
+ * paragraph, and a paragraph inside the caption span is invalid nesting that the
+ * browser hoists apart, leaving the caption empty in the DOM.
+ */
+import type { BenchmarkComparison } from '../lib/benchmarks';
+import { formatProjects, formatSeconds, formatSpeedup, headline } from '../lib/benchmarks';
+
+interface Props {
+	data: BenchmarkComparison;
+}
+
+const { data } = Astro.props;
+const top = headline(data);
+const baselineRef = data.comparison.baseline.ref;
+---
+
+<div class="hero-figure">
+	<div class="hero-value">{formatSpeedup(top.speedup)} faster</div>
+	<div class="hero-caption">
+		on a {formatProjects(top.totalProjects)}-project repository — {
+			formatSeconds(top.baseline.meanSeconds)
+		} at {baselineRef} against {formatSeconds(top.candidate.meanSeconds)} at v7
+	</div>
+</div>
+
+<style>
+	.hero-figure {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+		margin: 1.5rem 0 1.75rem;
+	}
+
+	.hero-value {
+		font-size: clamp(2.5rem, 8vw, 3.5rem);
+		font-weight: 700;
+		line-height: 1.05;
+		color: var(--sl-color-white);
+	}
+
+	.hero-caption {
+		color: var(--sl-color-gray-2);
+		font-size: var(--sl-text-base);
+		max-width: 52ch;
+	}
+</style>

--- a/docs/src/components/BenchmarkTable.astro
+++ b/docs/src/components/BenchmarkTable.astro
@@ -1,0 +1,69 @@
+---
+/**
+ * The table view of a comparison. Present so the charts never carry a number that
+ * cannot be read exactly, and so the spread behind each mean is visible.
+ */
+import type { BenchmarkComparison } from '../lib/benchmarks';
+import { formatProjects, formatSeconds } from '../lib/benchmarks';
+
+interface Props {
+	data: BenchmarkComparison;
+}
+
+const { data } = Astro.props;
+const rows = [...data.measurements].sort((a, b) => a.totalProjects - b.totalProjects);
+const baselineRef = data.comparison.baseline.ref;
+---
+
+<div class="table-scroll">
+	<table>
+		<thead>
+			<tr>
+				<th>Projects</th>
+				<th>Graph nodes</th>
+				<th>{baselineRef}</th>
+				<th>v7</th>
+				<th>Change</th>
+				<th>Speedup</th>
+				<th>Iterations</th>
+			</tr>
+		</thead>
+		<tbody>
+			{
+				rows.map(row => (
+					<tr>
+						<td>{formatProjects(row.totalProjects)}</td>
+						<td>{formatProjects(row.graphNodes)}</td>
+						<td>
+							{formatSeconds(row.baseline.meanSeconds)}
+							<span class="spread">± {row.baseline.stdDevPercentOfMean}%</span>
+						</td>
+						<td>
+							{formatSeconds(row.candidate.meanSeconds)}
+							<span class="spread">± {row.candidate.stdDevPercentOfMean}%</span>
+						</td>
+						<td>{row.changePercent}%</td>
+						<td><strong>{row.speedup}×</strong></td>
+						<td>{row.iterations}</td>
+					</tr>
+				))
+			}
+		</tbody>
+	</table>
+</div>
+
+<style>
+	.table-scroll {
+		overflow-x: auto;
+	}
+
+	table {
+		font-variant-numeric: tabular-nums;
+	}
+
+	.spread {
+		display: block;
+		color: var(--sl-color-gray-3);
+		font-size: var(--sl-text-xs);
+	}
+</style>

--- a/docs/src/components/ReleaseCallout.astro
+++ b/docs/src/components/ReleaseCallout.astro
@@ -1,0 +1,42 @@
+---
+/**
+ * The landing page's release line: what is available, and the one number that says
+ * why it is worth moving to. Reads the newest benchmark snapshot, so it follows the
+ * data rather than repeating a figure that will go stale.
+ */
+import { formatProjects, formatSpeedup, headline, latest } from '../lib/benchmarks';
+
+const top = latest ? headline(latest.data) : undefined;
+---
+
+{
+	latest && top && (
+		<aside class="release-callout">
+			<p>
+				<strong>v{latest.release} is available.</strong>{' '}
+				<a href="/performance/">
+					{formatSpeedup(top.speedup)} faster than {latest.data.comparison.baseline.ref}
+				</a>{' '}
+				on a {formatProjects(top.totalProjects)}-project repository, and the gap widens with
+				repository size. <a href="/upgrading/v6-to-v7/">See what changed</a>.
+			</p>
+		</aside>
+	)
+}
+
+<style>
+	.release-callout {
+		margin: 0 0 2rem;
+		padding: 0.9rem 1.1rem;
+		border: 1px solid var(--sl-color-gray-5);
+		border-inline-start: 4px solid var(--sl-color-accent);
+		border-radius: 0.35rem;
+		background: var(--sl-color-gray-6);
+	}
+
+	.release-callout p {
+		margin: 0;
+		font-size: var(--sl-text-base);
+		line-height: 1.5;
+	}
+</style>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -18,6 +18,9 @@ hero:
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
+import ReleaseCallout from '../../components/ReleaseCallout.astro';
+
+<ReleaseCallout />
 
 ## What it does
 
@@ -61,5 +64,8 @@ dotnet-affected compares your working tree against a baseline commit — a branc
 	</Card>
 	<Card title="CLI reference" icon="list-format">
 		[Every option](/reference/cli/), including `--filter-file-path` and the exclusion flags.
+	</Card>
+	<Card title="Performance" icon="rocket">
+		[How v7 compares with v6](/performance/) on the same repositories, and how it was measured.
 	</Card>
 </CardGrid>

--- a/docs/src/content/docs/performance.mdx
+++ b/docs/src/content/docs/performance.mdx
@@ -14,6 +14,8 @@ export const top = headline(latest.data);
 export const smallest = [...latest.data.measurements].sort(
 	(a, b) => a.totalProjects - b.totalProjects,
 )[0];
+export const reproductionHours =
+	Math.round(latest.data.measurements.reduce((sum, m) => sum + m.sizeDurationSeconds, 0) / 360) / 10;
 
 <BenchmarkHero data={latest.data} />
 
@@ -28,8 +30,8 @@ is the point worth taking from this page, since large repositories are what this
 <BenchmarkTable data={latest.data} />
 
 Both versions produced the **same affected projects** at every size, so this is not one of them
-doing less work. The run at {formatProjects(top.totalProjects)} projects reports
-{' '}{top.affectedProjects} affected out of {formatProjects(top.totalProjects)}.
+doing less work: the run at {formatProjects(top.totalProjects)} projects reports {formatProjects(top.affectedProjects)} affected
+out of {formatProjects(top.totalProjects)}.
 
 ## Why it scales better
 
@@ -92,19 +94,8 @@ Part of v7's gain comes from discovery no longer walking `.git` or
 [BenchmarkDotNet suites](https://github.com/leonardochaia/dotnet-affected/tree/main/benchmarks) run
 on every push to `main` and isolate the algorithm from discovery; this page is the end-to-end view.
 
-Reproducing the whole comparison takes about
-{Math.round(latest.data.measurements.reduce((sum, m) => sum + m.sizeDurationSeconds, 0) / 360) / 10}
-{' '}hours of wall clock, most of it spent on the baseline at the largest size.
-
-{latest.data.notMeasured?.length ? (
-	<Aside title="Where it stops">
-		{latest.data.notMeasured.map(entry => (
-			<p>
-				<strong>{formatProjects(entry.totalProjects)} projects:</strong> {entry.reason}
-			</p>
-		))}
-	</Aside>
-) : null}
+Reproducing the whole comparison takes about {reproductionHours} hours of wall clock, most of it
+spent on the baseline at the largest size.
 
 ## Data
 

--- a/docs/src/content/docs/performance.mdx
+++ b/docs/src/content/docs/performance.mdx
@@ -17,10 +17,9 @@ export const smallest = [...latest.data.measurements].sort(
 
 <BenchmarkHero data={latest.data} />
 
-The win grows with the repository. At {formatProjects(smallest.totalProjects)} projects v7 is
-{' '}{formatSpeedup(smallest.speedup)} faster; at {formatProjects(top.totalProjects)} it is {formatSpeedup(top.speedup)}. That is the
-point worth taking from this page: the larger the repository, the more v7 saves — and large
-repositories are what this tool is for.
+Every figure on this page compares **v7 against {latest.data.comparison.baseline.ref}**, the last v6
+release, over identical generated repositories. The larger the repository, the more v7 saves — which
+is the point worth taking from this page, since large repositories are what this tool is for.
 
 <BenchmarkCharts data={latest.data} />
 

--- a/docs/src/content/docs/performance.mdx
+++ b/docs/src/content/docs/performance.mdx
@@ -1,0 +1,137 @@
+---
+title: Performance
+description: How dotnet-affected v7 compares with v6 on the same repositories, and how the numbers were produced.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import BenchmarkHero from '../../components/BenchmarkHero.astro';
+import BenchmarkCharts from '../../components/BenchmarkCharts.astro';
+import BenchmarkTable from '../../components/BenchmarkTable.astro';
+import { releases, headline, formatProjects, formatSeconds, formatSpeedup } from '../../lib/benchmarks';
+
+export const latest = releases[0];
+export const top = headline(latest.data);
+export const smallest = [...latest.data.measurements].sort(
+	(a, b) => a.totalProjects - b.totalProjects,
+)[0];
+
+<BenchmarkHero data={latest.data} />
+
+The win grows with the repository. At {formatProjects(smallest.totalProjects)} projects v7 is
+{' '}{formatSpeedup(smallest.speedup)} faster; at {formatProjects(top.totalProjects)} it is {formatSpeedup(top.speedup)}. That is the
+point worth taking from this page: the larger the repository, the more v7 saves — and large
+repositories are what this tool is for.
+
+<BenchmarkCharts data={latest.data} />
+
+## The numbers
+
+<BenchmarkTable data={latest.data} />
+
+Both versions produced the **same affected projects** at every size, so this is not one of them
+doing less work. The run at {formatProjects(top.totalProjects)} projects reports
+{' '}{top.affectedProjects} affected out of {formatProjects(top.totalProjects)}.
+
+## Why it scales better
+
+Cost growth per doubling, as an exponent: 1 is linear, 2 quadratic, 3 cubic.
+
+<div class="table-scroll">
+	<table>
+		<thead>
+			<tr>
+				<th>Step</th>
+				<th>{latest.data.comparison.baseline.ref}</th>
+				<th>v7</th>
+			</tr>
+		</thead>
+		<tbody>
+			{latest.data.scaling.baseline.map((step, i) => (
+				<tr>
+					<td>
+						{formatProjects(step.fromProjects)} → {formatProjects(step.toProjects)}
+					</td>
+					<td>{step.exponent}</td>
+					<td>{latest.data.scaling.candidate[i].exponent}</td>
+				</tr>
+			))}
+		</tbody>
+	</table>
+</div>
+
+v6's cost climbs from roughly linear to worse than quadratic as the repository grows. v7's stays
+under 2 across the same range. Neither exponent is constant, so neither should be extrapolated past
+the largest size measured.
+
+## How this was measured
+
+<Aside type="caution" title="These are desktop numbers">
+	They were produced on an unloaded desktop, not a CI runner, and they are comparable **to each
+	other and to nothing else**. Both sides were built with the same SDK, resolve the same MSBuild,
+	and each pair ran interleaved against one generated repository. Absolute figures on your
+	hardware will differ; the ratio is the transferable part.
+</Aside>
+
+| | |
+|---|---|
+| Baseline | `{latest.data.comparison.baseline.ref}` ({latest.data.comparison.baseline.commit.slice(0, 8)}) |
+| Candidate | `{latest.data.comparison.candidate.ref}` ({latest.data.comparison.candidate.commit.slice(0, 8)}) |
+| Invocation | `{latest.data.method.invocation}` |
+| Repository shape | {latest.data.method.repositoryShape} |
+| CPU | {latest.data.environment.cpu} |
+| OS | {latest.data.environment.os}, {latest.data.environment.kernel} |
+| .NET SDK | {latest.data.environment.dotnetSdk} |
+| MSBuild | {latest.data.environment.msbuild} |
+| Configuration | {latest.data.environment.configuration} |
+
+Measurement is at the **process** level: the executables are run and timed, so startup and MSBuild
+load count, which is what a user actually waits for. One warmup run per version is discarded, and
+the two versions alternate so drift affects both equally.
+
+Part of v7's gain comes from discovery no longer walking `.git` or
+[gitignored paths](/guides/project-discovery/#ignored-paths), not only from the graph work. The
+[BenchmarkDotNet suites](https://github.com/leonardochaia/dotnet-affected/tree/main/benchmarks) run
+on every push to `main` and isolate the algorithm from discovery; this page is the end-to-end view.
+
+Reproducing the whole comparison takes about
+{Math.round(latest.data.measurements.reduce((sum, m) => sum + m.sizeDurationSeconds, 0) / 360) / 10}
+{' '}hours of wall clock, most of it spent on the baseline at the largest size.
+
+{latest.data.notMeasured?.length ? (
+	<Aside title="Where it stops">
+		{latest.data.notMeasured.map(entry => (
+			<p>
+				<strong>{formatProjects(entry.totalProjects)} projects:</strong> {entry.reason}
+			</p>
+		))}
+	</Aside>
+) : null}
+
+## Data
+
+Every figure here is generated from a JSON snapshot committed alongside the site, one per release,
+under `docs/src/data/benchmarks/`. The snapshots hold the raw per-iteration timings where they were
+captured, and every derived field — change, speedup, cost ratio, exponent — is computed rather than
+transcribed. Snapshots are never regenerated: a published comparison that changes underneath a
+reader is not a comparison.
+
+{releases.length > 1 ? (
+	<ul>
+		{releases.slice(1).map(entry => (
+			<li>
+				<a href={`#v${entry.release}`}>v{entry.release}</a> — measured{' '}
+				{entry.data.generatedAt.slice(0, 10)}
+			</li>
+		))}
+	</ul>
+) : (
+	<p>v{latest.release} is the first release with a published comparison.</p>
+)}
+
+<style>
+	{`
+	.table-scroll {
+		overflow-x: auto;
+	}
+	`}
+</style>

--- a/docs/src/content/docs/performance.mdx
+++ b/docs/src/content/docs/performance.mdx
@@ -73,9 +73,9 @@ the largest size measured.
 
 | | |
 |---|---|
-| Baseline | `{latest.data.comparison.baseline.ref}` ({latest.data.comparison.baseline.commit.slice(0, 8)}) |
-| Candidate | `{latest.data.comparison.candidate.ref}` ({latest.data.comparison.candidate.commit.slice(0, 8)}) |
-| Invocation | `{latest.data.method.invocation}` |
+| Baseline | <code>{latest.data.comparison.baseline.ref}</code> ({latest.data.comparison.baseline.commit.slice(0, 8)}) |
+| Candidate | <code>{latest.data.comparison.candidate.ref}</code> ({latest.data.comparison.candidate.commit.slice(0, 8)}) |
+| Invocation | <code>{latest.data.method.invocation}</code> |
 | Repository shape | {latest.data.method.repositoryShape} |
 | CPU | {latest.data.environment.cpu} |
 | OS | {latest.data.environment.os}, {latest.data.environment.kernel} |

--- a/docs/src/content/docs/upgrading/v6-to-v7.md
+++ b/docs/src/content/docs/upgrading/v6-to-v7.md
@@ -9,6 +9,21 @@ Most v6 setups keep working unchanged on v7: every removed option still has a wo
 you already use are unchanged. What does change is what gets **discovered** — read the first section even if you
 change nothing else.
 
+## Why upgrade
+
+v7 is faster on the same repositories, and the difference grows with size — 6.5× faster at 2,000
+projects, where v6 takes over twelve minutes and v7 takes under two.
+
+| Projects | v6.2.0 | v7 | Speedup |
+|---|---|---|---|
+| 250 | 7.80s | 5.90s | 1.3× |
+| 500 | 17.1s | 10.9s | 1.6× |
+| 1,000 | 79.9s | 28.1s | 2.8× |
+| 2,000 | 727s | 111s | 6.5× |
+
+Desktop numbers, comparable to each other and nothing else. Both versions reported the same affected
+projects at every size. [Full method and charts](/performance/).
+
 ## Behaviour changes
 
 ### Every comparison ends at the working tree

--- a/docs/src/data/benchmarks/v7.0.0.json
+++ b/docs/src/data/benchmarks/v7.0.0.json
@@ -1,0 +1,242 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-17T12:59:17+00:00",
+  "description": "Wall clock of the dotnet-affected CLI at v6.2.0 against the working tree, over identical generated repositories. Produced by eng/benchmark-compare.sh.",
+  "comparison": {
+    "baseline": {
+      "ref": "v6.2.0",
+      "commit": "a88f3d63831f805508094f51bdde248e1dedbded",
+      "committedAt": "2025-11-19T07:59:54-03:00"
+    },
+    "candidate": {
+      "ref": "main",
+      "commit": "699ebb47f75710db5c9b739703687c5995e70f78",
+      "committedAt": "2026-08-16T11:53:51-03:00",
+      "subject": "ci: default CI to the Release configuration (#179)"
+    }
+  },
+  "environment": {
+    "cpu": "AMD Ryzen 7 PRO 8840U w/ Radeon 780M Graphics",
+    "kernel": "Linux 7.1.5-201.fc44.x86_64 x86_64",
+    "os": "fedora 44",
+    "dotnetSdk": "10.0.201",
+    "msbuild": "18.3.0-release-26153-122+4d3023de6",
+    "targetFramework": "net10.0",
+    "configuration": "Release",
+    "note": "Unloaded desktop, not a CI runner. Both sides were built with the same SDK and resolve the same MSBuild, and each pair ran interleaved against one repository, so the two columns are comparable to each other and to nothing else."
+  },
+  "method": {
+    "kind": "process",
+    "invocation": "dotnet-affected -p <repo> --dry-run --format text",
+    "interleaved": true,
+    "warmupRunsDiscardedPerVersion": 1,
+    "harness": "benchmarks/dotnet-affected.Benchmarks -- compare",
+    "driver": "eng/benchmark-compare.sh",
+    "repositoryShape": "Generated csproj tree, 20 children per project, one added .cs file in every fifth project, committed clean then dirtied.",
+    "whyProcess": "The two versions ship the same assembly names and differ only in version, so one shadows the other in process. Running the executables also measures startup and MSBuild load, which is what a user waits for."
+  },
+  "measurements": [
+    {
+      "totalProjects": 250,
+      "childrenPerProject": 20,
+      "graphNodes": 1000,
+      "changedFiles": 200,
+      "affectedProjects": 245,
+      "outputsMatch": true,
+      "iterations": 10,
+      "baseline": {
+        "minSeconds": 7.1,
+        "meanSeconds": 7.8,
+        "stdDevSeconds": 0.49,
+        "stdDevPercentOfMean": 6.28,
+        "samplesSeconds": null
+      },
+      "candidate": {
+        "minSeconds": 5.46,
+        "meanSeconds": 5.9,
+        "stdDevSeconds": 0.43,
+        "stdDevPercentOfMean": 7.29,
+        "samplesSeconds": null
+      },
+      "changePercent": -24.4,
+      "speedup": 1.32,
+      "sizeDurationSeconds": 166,
+      "sourceLog": "compare-20260816-145248.log"
+    },
+    {
+      "totalProjects": 500,
+      "childrenPerProject": 20,
+      "graphNodes": 2000,
+      "changedFiles": 400,
+      "affectedProjects": 497,
+      "outputsMatch": true,
+      "iterations": 10,
+      "baseline": {
+        "minSeconds": 16.45,
+        "meanSeconds": 17.09,
+        "stdDevSeconds": 0.44,
+        "stdDevPercentOfMean": 2.57,
+        "samplesSeconds": null
+      },
+      "candidate": {
+        "minSeconds": 10.61,
+        "meanSeconds": 10.87,
+        "stdDevSeconds": 0.23,
+        "stdDevPercentOfMean": 2.12,
+        "samplesSeconds": null
+      },
+      "changePercent": -36.4,
+      "speedup": 1.57,
+      "sizeDurationSeconds": 327,
+      "sourceLog": "compare-20260816-145248.log"
+    },
+    {
+      "totalProjects": 1000,
+      "childrenPerProject": 20,
+      "graphNodes": 4000,
+      "changedFiles": 800,
+      "affectedProjects": 995,
+      "outputsMatch": true,
+      "iterations": 10,
+      "baseline": {
+        "minSeconds": 77.74,
+        "meanSeconds": 79.91,
+        "stdDevSeconds": 1.56,
+        "stdDevPercentOfMean": 1.95,
+        "samplesSeconds": null
+      },
+      "candidate": {
+        "minSeconds": 27.03,
+        "meanSeconds": 28.12,
+        "stdDevSeconds": 0.68,
+        "stdDevPercentOfMean": 2.42,
+        "samplesSeconds": null
+      },
+      "changePercent": -64.8,
+      "speedup": 2.84,
+      "sizeDurationSeconds": 1224,
+      "sourceLog": "compare-20260816-145248.log"
+    },
+    {
+      "totalProjects": 2000,
+      "childrenPerProject": 20,
+      "graphNodes": 8000,
+      "changedFiles": 1600,
+      "affectedProjects": 1994,
+      "outputsMatch": true,
+      "iterations": 5,
+      "baseline": {
+        "minSeconds": 715.42,
+        "meanSeconds": 726.88,
+        "stdDevSeconds": 10.24,
+        "stdDevPercentOfMean": 1.41,
+        "samplesSeconds": [
+          734.69,
+          727.79,
+          715.42,
+          717.69,
+          738.8
+        ]
+      },
+      "candidate": {
+        "minSeconds": 102.75,
+        "meanSeconds": 111.41,
+        "stdDevSeconds": 4.9,
+        "stdDevPercentOfMean": 4.4,
+        "samplesSeconds": [
+          114.04,
+          114.52,
+          113.01,
+          112.75,
+          102.75
+        ]
+      },
+      "changePercent": -84.7,
+      "speedup": 6.52,
+      "sizeDurationSeconds": 5139,
+      "sourceLog": "compare-20260817-011610.log"
+    }
+  ],
+  "scaling": {
+    "note": "Cost growth per step. The exponent is log(costRatio)/log(sizeRatio): 1 is linear, 2 quadratic, 3 cubic. It is not constant for either version, so it should not be extrapolated far beyond the measured range.",
+    "baseline": [
+      {
+        "fromProjects": 250,
+        "toProjects": 500,
+        "costRatio": 2.191,
+        "exponent": 1.132
+      },
+      {
+        "fromProjects": 500,
+        "toProjects": 1000,
+        "costRatio": 4.676,
+        "exponent": 2.225
+      },
+      {
+        "fromProjects": 1000,
+        "toProjects": 2000,
+        "costRatio": 9.096,
+        "exponent": 3.185
+      }
+    ],
+    "candidate": [
+      {
+        "fromProjects": 250,
+        "toProjects": 500,
+        "costRatio": 1.842,
+        "exponent": 0.882
+      },
+      {
+        "fromProjects": 500,
+        "toProjects": 1000,
+        "costRatio": 2.587,
+        "exponent": 1.371
+      },
+      {
+        "fromProjects": 1000,
+        "toProjects": 2000,
+        "costRatio": 3.962,
+        "exponent": 1.986
+      }
+    ]
+  },
+  "abandonedRuns": [
+    {
+      "totalProjects": 2000,
+      "graphNodes": 8000,
+      "affectedProjects": 1998,
+      "outputsMatch": true,
+      "iterations": 10,
+      "outcome": "killed by the time budget after 5484s, before any timing was printed",
+      "reason": "The driver projected the size at three times the previous one; actual growth was steeper. The harness only printed after all iterations, so nothing survived. Both fixed afterwards.",
+      "sourceLog": "compare-20260816-145248.log"
+    }
+  ],
+  "notMeasured": [
+    {
+      "totalProjects": 4000,
+      "reason": "Extrapolating the observed 9.1x baseline growth puts one v6.2.0 run near 6500s, so a warmup plus a single iteration is over 3.5h of baseline alone. Refused by the driver's budget guard."
+    }
+  ],
+  "sourceLogs": [
+    {
+      "file": "compare-20260816-145248.log",
+      "sizes": [
+        250,
+        500,
+        1000,
+        2000
+      ],
+      "iterations": 10,
+      "note": "2000 was killed by the budget."
+    },
+    {
+      "file": "compare-20260817-011610.log",
+      "sizes": [
+        2000
+      ],
+      "iterations": 5,
+      "note": "Re-run of the size the first run lost, with per-iteration logging."
+    }
+  ]
+}

--- a/docs/src/lib/benchmarks.ts
+++ b/docs/src/lib/benchmarks.ts
@@ -1,0 +1,113 @@
+/**
+ * Loads the benchmark comparison snapshots under src/data/benchmarks.
+ *
+ * One file per release, named after it. The release is read from the file name so
+ * the snapshots stay exactly as the generator wrote them: they are the record of a
+ * run that happened, and nothing here should be able to edit the numbers.
+ */
+
+export interface BenchmarkStats {
+	minSeconds: number;
+	meanSeconds: number;
+	stdDevSeconds: number;
+	stdDevPercentOfMean: number;
+	samplesSeconds: number[] | null;
+}
+
+export interface BenchmarkMeasurement {
+	totalProjects: number;
+	childrenPerProject: number;
+	graphNodes: number;
+	changedFiles: number;
+	affectedProjects: number;
+	outputsMatch: boolean;
+	iterations: number;
+	baseline: BenchmarkStats;
+	candidate: BenchmarkStats;
+	changePercent: number;
+	speedup: number;
+	sizeDurationSeconds: number;
+	sourceLog: string;
+}
+
+export interface ScalingStep {
+	fromProjects: number;
+	toProjects: number;
+	costRatio: number;
+	exponent: number;
+}
+
+export interface BenchmarkComparison {
+	schemaVersion: number;
+	generatedAt: string;
+	description: string;
+	comparison: {
+		baseline: { ref: string; commit: string; committedAt: string };
+		candidate: { ref: string; commit: string; committedAt: string; subject?: string };
+	};
+	environment: Record<string, string>;
+	method: Record<string, string | boolean | number>;
+	measurements: BenchmarkMeasurement[];
+	scaling: { note: string; baseline: ScalingStep[]; candidate: ScalingStep[] };
+	abandonedRuns?: unknown[];
+	notMeasured?: { totalProjects: number; reason: string }[];
+	sourceLogs?: unknown[];
+}
+
+export interface BenchmarkRelease {
+	/** Release the snapshot was taken for, from the file name: `v7.0.0.json` → `7.0.0`. */
+	release: string;
+	data: BenchmarkComparison;
+}
+
+const files = import.meta.glob<BenchmarkComparison>('../data/benchmarks/*.json', {
+	eager: true,
+	import: 'default',
+});
+
+/** Numeric-aware descending sort, so 7.0.0 sorts above 6.10.0 rather than below it. */
+function compareReleases(a: string, b: string): number {
+	const parts = (release: string) => release.split(/[.-]/).map(part => Number(part) || 0);
+	const [left, right] = [parts(a), parts(b)];
+
+	for (let i = 0; i < Math.max(left.length, right.length); i++) {
+		const diff = (right[i] ?? 0) - (left[i] ?? 0);
+		if (diff !== 0) return diff;
+	}
+
+	return 0;
+}
+
+export const releases: BenchmarkRelease[] = Object.entries(files)
+	.map(([path, data]) => ({
+		release: path.replace(/^.*\/v?/, '').replace(/\.json$/, ''),
+		data,
+	}))
+	.sort((a, b) => compareReleases(a.release, b.release));
+
+export const latest: BenchmarkRelease | undefined = releases[0];
+
+/** The largest size measured, which is where the difference is biggest. */
+export function headline(data: BenchmarkComparison): BenchmarkMeasurement {
+	return data.measurements.reduce((biggest, m) =>
+		m.totalProjects > biggest.totalProjects ? m : biggest,
+	);
+}
+
+export function formatSeconds(seconds: number): string {
+	if (seconds >= 100) return `${Math.round(seconds)}s`;
+	if (seconds >= 10) return `${seconds.toFixed(1)}s`;
+	return `${seconds.toFixed(2)}s`;
+}
+
+export function formatProjects(count: number): string {
+	return count.toLocaleString('en-US');
+}
+
+/**
+ * One decimal, for prose and chart labels. The table shows the unrounded value:
+ * a label is an approximation, a table is the record.
+ */
+export function formatSpeedup(speedup: number): string {
+	return `${speedup.toFixed(1)}×`;
+}

--- a/docs/src/styles/layout.css
+++ b/docs/src/styles/layout.css
@@ -1,0 +1,25 @@
+/*
+ * Layout adjustments on top of Starlight's defaults.
+ *
+ * Starlight sizes the table-of-contents column from whatever width is left after
+ * the sidebar and the content, so on a wide screen it grows without bound: at
+ * 1920px it measured 593px, wider than the 720px of prose it indexes, and the page
+ * read as mostly table of contents. Capping it turns that surplus into margin.
+ *
+ * The content width is only nudged. Starlight's 45rem is 87 characters per line at
+ * this font, already at the top of the comfortable range, so there is little to win
+ * by widening prose — 50rem buys 96 characters, which pays for itself on the wide
+ * code blocks and tables in the reference pages without hurting reading much.
+ */
+
+@media (min-width: 72rem) {
+	:root {
+		--sl-content-width: 50rem;
+		/* Enough for two-line entries like "Without installing: the MSBuild SDK". */
+		--docs-toc-width: 16rem;
+	}
+
+	.right-sidebar-container {
+		width: var(--docs-toc-width);
+	}
+}


### PR DESCRIPTION
Publishes the v6.2.0 to v7 comparison as a Performance page, and surfaces its headline figure where people decide whether to upgrade.

## The data

One JSON snapshot per release under `docs/src/data/benchmarks/`, named after the release — `v7.0.0.json` is the generator's output, unedited. Every figure the page shows is computed from it at build time, so nothing is transcribed twice, and the release label comes from the file name rather than a field, which keeps the snapshot exactly as the run produced it.

Snapshots are never regenerated. A published comparison that changes underneath a reader is not a comparison; a new release adds a file next to the old ones.

## The page

`/performance/`: headline figure, two charts, the numbers as a table, the scaling exponents, and the method.

Both charts render to SVG at build time, so the page ships no client JavaScript.

- **Speedup bars are zero based.** Bars encode length, and anchoring them at 1x turned a 4.9x difference in the data into a 17x difference on screen. A dashed reference line marks 1x, where nothing changed.
- **Wall clock is a dumbbell on a log axis.** Position encoding, so there is no zero to misrepresent, and the sizes span two orders of magnitude — 5.9s to 727s on one linear axis leaves the two smallest sizes invisible.
- **Colour is one hue at two steps**, the before/after pair for a dumbbell, validated against both site surfaces (`#ffffff`, `#17181c`) in both modes. The speedup chart is a single series and carries no legend.
- Hover text on every mark via SVG `<title>`, and the table view carries the exact numbers with the spread behind each mean.

## What the numbers say

| Projects | v6.2.0 | v7 | Speedup |
|---|---|---|---|
| 250 | 7.80s | 5.90s | 1.3x |
| 500 | 17.1s | 10.9s | 1.6x |
| 1,000 | 79.9s | 28.1s | 2.8x |
| 2,000 | 727s | 111s | 6.5x |

Both versions reported the same affected projects at every size, so this is not one of them doing less work.

The page states plainly that these are desktop numbers, comparable to each other and nothing else, and that part of the gain is discovery no longer walking `.git` or gitignored paths rather than the graph work alone — the BenchmarkDotNet suites on `main` isolate that, and the page links to them.

## Where it shows up

- **Landing page**: a release callout reading the same snapshot, so the figure follows the data, plus a Performance card in the grid.
- **Upgrade guide**: a *Why upgrade* section leading with the table, above the behaviour changes.
- **Sidebar**: under Reference.

## Adding the next release

Drop `v7.1.0.json` into `docs/src/data/benchmarks/`. The page picks up the newest by version order, the landing callout follows it, and older snapshots are listed under Data.
