### PR TITLE
fix: turn off git rename detection

### DIFF
--- a/src/DotnetAffected.Core/GitChangesProvider.cs
+++ b/src/DotnetAffected.Core/GitChangesProvider.cs
@@ -17,6 +17,21 @@ namespace DotnetAffected.Core
     {
         internal static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
+        /// <summary>
+        /// Rename detection, which libgit2 performs by default, pairs a deletion with an addition
+        /// and reports the two as a single entry carrying only the new path. Moving a file from one
+        /// project to another then never reports the project the file left as changed, and the old
+        /// path never reaches <see cref="FileSystem.DeletedFilesOverlayFileSystem"/> to be restored
+        /// for evaluation. Both paths are changes here, and rename identity is of no use to us, so
+        /// the pairing is turned off. It is also the expensive part of the diff: it compares the
+        /// content of every addition against every deletion, and gives up entirely once git's
+        /// rename limit is reached.
+        /// </summary>
+        private static readonly CompareOptions NoRenameDetection = new CompareOptions
+        {
+            Similarity = SimilarityOptions.None
+        };
+
         /// <inheritdoc />
         public IEnumerable<string> GetChangedFiles(string directory, string from, UncommittedChanges uncommitted)
         {
@@ -170,7 +185,9 @@ namespace DotnetAffected.Core
             return repository.Diff.Compare<T>(
                 tree,
                 targets,
-                files);
+                files,
+                explicitPathsOptions: null,
+                NoRenameDetection);
         }
 
         private static T GetChangesBetweenTrees<T>(
@@ -183,7 +200,8 @@ namespace DotnetAffected.Core
             return repository.Diff.Compare<T>(
                 fromTree,
                 toTree,
-                files);
+                files,
+                NoRenameDetection);
         }
 
         private static Commit GetCommitOrHead(Repository repository, string name)

--- a/test/DotnetAffected.Core.Tests/MovedFileChangeDetectionTests.cs
+++ b/test/DotnetAffected.Core.Tests/MovedFileChangeDetectionTests.cs
@@ -1,0 +1,98 @@
+using DotnetAffected.Testing.Utils;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DotnetAffected.Core.Tests
+{
+    /// <summary>
+    /// Moving a file from one project to another.
+    ///
+    /// Git reports a move as a single rename entry when rename detection is on, which carries
+    /// only the new path. The project the file left keeps compiling a smaller set of files and
+    /// nothing attributes the change to it, so it is never reported as changed and the old path
+    /// never reaches the deleted files overlay either.
+    /// </summary>
+    public class MovedFileChangeDetectionTests
+        : BaseDotnetAffectedTest
+    {
+        private const string SourceProject = "InventoryManagement";
+        private const string TargetProject = "OrderManagement";
+
+        private string _fromCommit;
+
+        protected override AffectedOptions Options =>
+            new AffectedOptions(Repository.Path, fromRef: _fromCommit);
+
+        /// <summary>
+        /// The move is committed, so the comparison is between two trees.
+        /// </summary>
+        [Fact]
+        public async Task When_file_is_moved_between_projects_both_projects_should_have_changes()
+        {
+            var (source, target) = await CreateProjectsWithMovableFile();
+
+            _fromCommit = Repository.StageAndCommit()
+                .Sha;
+
+            MoveFile();
+            Repository.StageAndCommit();
+
+            AssertBothProjectsChanged(source, target);
+        }
+
+        /// <summary>
+        /// The move is staged but not committed, so the comparison is against the working tree.
+        /// </summary>
+        [Fact]
+        public async Task When_staged_file_is_moved_between_projects_both_projects_should_have_changes()
+        {
+            var (source, target) = await CreateProjectsWithMovableFile();
+
+            _fromCommit = Repository.StageAndCommit()
+                .Sha;
+
+            MoveFile();
+            Repository.StageAll();
+
+            AssertBothProjectsChanged(source, target);
+        }
+
+        private async Task<(string SourcePath, string TargetPath)> CreateProjectsWithMovableFile()
+        {
+            var source = Repository.CreateCsProject(SourceProject);
+            var target = Repository.CreateCsProject(TargetProject);
+
+            // Long enough for git to consider the two paths similar to each other.
+            await Repository.CreateTextFileAsync(
+                Path.Combine(SourceProject, "Moved.cs"),
+                string.Join("\n", Enumerable.Range(0, 50).Select(i => $"// line {i}")));
+
+            return (source.FullPath, target.FullPath);
+        }
+
+        private void MoveFile()
+        {
+            File.Move(
+                Path.Combine(Repository.Path, SourceProject, "Moved.cs"),
+                Path.Combine(Repository.Path, TargetProject, "Moved.cs"));
+        }
+
+        private void AssertBothProjectsChanged(string sourceProjectPath, string targetProjectPath)
+        {
+            // Both the path the file left and the path it arrived at are changes.
+            Assert.Equal(2, AffectedSummary.FilesThatChanged.Count());
+
+            var changedProjects = AffectedSummary.ProjectsWithChangedFiles
+                .Select(p => p.GetFullPath())
+                .OrderBy(p => p)
+                .ToArray();
+
+            Assert.Equal(
+                new[] { sourceProjectPath, targetProjectPath }.OrderBy(p => p)
+                    .ToArray(),
+                changedProjects);
+        }
+    }
+}


### PR DESCRIPTION
## The bug

`GitChangesProvider` asks libgit2 for a diff and takes `change.Path` from every entry. Rename detection is on by default, so a file moved from one project to another comes back as **one** entry holding only the new path:

```
--- default options
    Renamed    path=projB/Moved.cs oldPath=projA/Moved.cs
--- Similarity = None
    Deleted    path=projA/Moved.cs
    Added      path=projB/Moved.cs
```

Two consequences for a move across projects:

- the project the file left is never reported as changed, even though its compiled set shrank;
- the old path never reaches `DeletedFilesOverlayFileSystem`, so the file is not restored for evaluation.

It is also the expensive part of the diff — `git_diff_find_similar` compares the content of every addition against every deletion. Moving 3000 files:

```
default (rename detection on)   1.747s   entries=4999
Similarity = None               0.001s   entries=6000
```

Note `entries=4999` vs `6000`: git's rename limit kicks in, so the current behaviour is not even consistent at scale.

## The fix

Rename identity is of no use to this tool — both paths are changes — so both `Diff.Compare` call sites now pass `Similarity = SimilarityOptions.None`.

## Tests

`MovedFileChangeDetectionTests` covers a file moved between two projects, once committed (tree-to-tree diff) and once staged (working-tree diff), asserting both projects are reported as changed. Both fail on `main` (1 changed file, 1 changed project) and pass with the fix.

Full suite green: Core 135, CLI 57, Tasks 4.